### PR TITLE
[DEV] Modal 컴포넌트 유연성 확보 및 스크롤 금지 삭제

### DIFF
--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -20,14 +20,6 @@ const Modal = ({ title, description, onClose, className = '', children }: PropsW
         return () => window.removeEventListener('keydown', handleKeyDown)
     }, [onClose])
 
-    // 모달 창 열려 있는 동안 스크롤 금지
-    useEffect(() => {
-        document.body.style.overflow = 'hidden'
-        return () => {
-            document.body.style.overflow = ''
-        }
-    }, [])
-
     return (
         <div
             onClick={onClose} // 배경 클릭으로 모달 창 닫기

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -5,9 +5,10 @@ interface ModalProps {
     title: string
     description?: string
     onClose: () => void
+    className?: string // className을 props로 전달하여 모달의 스타일 수정이 가능합니다. 예) className="w-[486px]" 전달하여 모달의 크기를 고정
 }
 
-const Modal = ({ title, description, onClose, children }: PropsWithChildren<ModalProps>) => {
+const Modal = ({ title, description, onClose, className = '', children }: PropsWithChildren<ModalProps>) => {
     const modalRef = useRef<HTMLDivElement>(null)
 
     // ESC 키로 모달 창 닫기
@@ -42,10 +43,11 @@ const Modal = ({ title, description, onClose, children }: PropsWithChildren<Moda
             <div
                 ref={modalRef}
                 onClick={(e) => e.stopPropagation()}
-                className="
+                className={`
                     relative flex flex-col min-w-[288px] tablet:min-w-[384px] desktop:min-w-[486px]
                     space-y-4 tablet:space-y-6 bg-surface-elevate-l2 p-6 rounded-3xl
-                "
+                    ${className}
+                `}
             >
                 <button
                     type="button"


### PR DESCRIPTION
## 💡 Related Issue

closed #31 

## ✅ Summary

1. `// 모달 창 열려 있는 동안 스크롤 금지` 부분으로 인해 모달 띄울 때 전체 페이지에 대한 스크롤바가 사라지면서 화면이 좌우로 흔들리는 이슈를 해결했습니다.
2. 모달 공용 컴포넌트에 props를 추가하여 사이즈 유연성을 확보했습니다.

## 📝 Description

- [x] `// 모달 창 열려 있는 동안 스크롤 금지` 주석이 달린 `useEffect` 부분의 코드를 삭제했습니다. 따라서 모달 창이 열려 있어도 모달 뒤에 존재하는 **페이지의 스크롤이 가능**합니다.
---
- [x] **모달 컴포넌트에 `className` prop을 추가**하여 모달 div에 대한 스타일을 컴포넌트를 사용하는 측에서 커스텀할 수 있도록 했습니다.

```
// 사용 예시

<Modal
    title={`해당 영상에 대한\n 리포트를 받아보시겠어요?`}
    description="‘저 맘먹으면 광태님 꼬실 수 있어요ㅎ [월간데이트 4월호 ] (ENG / JP SUB)’을 유튜버님의 타겟과 컨셉을 고려하여 분석해요."
    onClose={() => console.log(1)}
    className="w-full max-w-[288px] tablet:max-w-[486px]"
>
    <div className="flex flex-row justify-end gap-2">
        <button>취소</button>
        <button>리포트 받기</button>
    </div>
</Modal>
```
<img width="542" height="229" alt="image" src="https://github.com/user-attachments/assets/2b12495d-1a59-4578-be8a-f39e9e42384a" />

- 길게 늘어져 보이지 않아요.

## 💬 리뷰 요구 사항

모달 컴포넌트 사용하신 분 머지하고 나서 모달 사용에 오류 없는지 확인 부탁드려요!
