### PR TITLE
[DEV] textarea 모달 공용 컴포넌트 리팩토링

### DIFF
--- a/frontend/src/components/ArrowButton.tsx
+++ b/frontend/src/components/ArrowButton.tsx
@@ -2,16 +2,18 @@ import Arrow from '../assets/icons/arrow.svg?react'
 import type { ButtonType } from '../types/common'
 
 interface ArrowButtonProps {
-    type?: ButtonType
-    isActive?: boolean
-    className?: string
+    type?: ButtonType // button 태그의 타입을 지정합니다. 디폴트는 button
+    onClick?: () => void // 버튼을 클릭했을 때 실행할 함수를 전달합니다.
+    isActive?: boolean // 버튼의 활성화 여부
+    className?: string // 추가로 적용할 css 클래스를 문자열로 전달합니다.
 }
 
-const ArrowButton = ({ type = 'button', isActive = true, className = '' }: ArrowButtonProps) => {
+const ArrowButton = ({ type = 'button', onClick, isActive = true, className = '' }: ArrowButtonProps) => {
     return (
         <button
             type={type}
             disabled={!isActive}
+            onClick={onClick}
             className={`
                 cursor-pointer right-0 flex justify-center items-center rounded-full
                 transition-colors duration-300 ${isActive ? 'bg-primary-500' : 'bg-neutral-white-opacity10'}

--- a/frontend/src/components/Textarea.tsx
+++ b/frontend/src/components/Textarea.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useRef, useState, type PropsWithChildren } from 'react'
+
+interface TextareaProps {
+    id: string // textarea 요소의 고유 id
+    value: string // textarea의 값
+    onChange: (value: string) => void // 사용자가 입력한 텍스트가 변경될 때 호출되는 함수
+    placeholder?: string
+    initialRows?: number // row 개수로 textarea 박스의 초기 높이를 지정할 수 있습니다. 디폴트는 1
+}
+
+const Textarea = ({
+    id,
+    value,
+    onChange,
+    placeholder,
+    initialRows = 1,
+    children,
+}: PropsWithChildren<TextareaProps>) => {
+    const [isFocused, setIsFocused] = useState(false)
+    const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+    // Desktop, Tablet: 5줄까지 textarea가 늘어납니다. 6줄 부터는 스크롤해서 확인합니다.
+    // Mobile: 3줄까지 textarea가 늘어납니다. 4줄 부터는 스크롤해서 확인합니다.
+    useEffect(() => {
+        const textarea = textareaRef.current
+        if (!textarea) return
+
+        textarea.style.height = 'auto'
+
+        const isMobile = window.innerWidth <= 768
+
+        const maxLines = isMobile ? 3 : 5
+        const maxHeight = 32 * maxLines
+        textarea.style.height = Math.min(textarea.scrollHeight, maxHeight) + 'px'
+    }, [value])
+
+    return (
+        <div
+            className={`
+                flex flex-col w-full min-w-[240px] tablet:min-w-[540px] desktop:min-w-[744px] p-4 space-y-6
+                border placeholder-gray-600 bg-neutral-white-opacity10 rounded-2xl
+                transition duration-300 ${isFocused ? 'border-gray-400' : 'border-transparent'}    
+            `}
+        >
+            <textarea
+                ref={textareaRef}
+                id={id}
+                value={value}
+                onChange={(e) => onChange(e.target.value)}
+                onFocus={() => setIsFocused(true)}
+                onBlur={() => setIsFocused(false)}
+                rows={initialRows}
+                placeholder={placeholder}
+                className="
+                    w-full h-fit max-h-[120px] px-2 outline-none resize-none focus:placeholder-transparent
+                    text-[14px] leading-[150%] tracking-[-0.35px] tablet:text-[16px] tablet:tracking-[-0.4px]
+                "
+            />
+
+            {children && <>{children}</>}
+        </div>
+    )
+}
+
+export default Textarea

--- a/frontend/src/components/TextareaWithArrow.tsx
+++ b/frontend/src/components/TextareaWithArrow.tsx
@@ -1,14 +1,17 @@
-import { useEffect, useRef, useState } from 'react'
 import ArrowButton from './ArrowButton'
 import type { ButtonType } from '../types/common'
+import Textarea from './Textarea'
 
 interface TextareaWithArrowProps {
-    id: string
-    value: string
-    onChange: (value: string) => void
+    id: string // textarea 요소의 고유 id
+    value: string // textarea의 현재 값
+    onChange: (value: string) => void // 사용자가 입력한 텍스트가 변경될 때 호출되는 함수
     placeholder?: string
-    isActive?: boolean
-    buttonType?: ButtonType
+    initialRows?: number // row 개수로 textarea 박스의 초기 높이를 지정할 수 있습니다. 디폴트는 1
+
+    isActive?: boolean // 화살표 버튼의 활성화 여부
+    handleButtonClick?: () => void // 화살표 버튼을 클릭했을 때 실행할 함수를 전달합니다.
+    buttonType?: ButtonType // button 태그의 타입을 지정합니다. 디폴트는 button
 }
 
 const TextareaWithArrow = ({
@@ -16,54 +19,17 @@ const TextareaWithArrow = ({
     value,
     onChange,
     placeholder,
+    initialRows = 1,
     isActive = true,
+    handleButtonClick,
     buttonType = 'button',
 }: TextareaWithArrowProps) => {
-    const [isFocused, setIsFocused] = useState(false)
-    const textareaRef = useRef<HTMLTextAreaElement>(null)
-    const isMobile = window.innerWidth <= 768
-
-    // Desktop, Tablet: 5줄까지 textarea가 늘어납니다. 6줄 부터는 스크롤해서 확인합니다.
-    // Mobile: 3줄까지 textarea가 늘어납니다. 4줄 부터는 스크롤해서 확인합니다.
-    useEffect(() => {
-        const textarea = textareaRef.current
-        if (!textarea) return
-
-        textarea.style.height = 'auto'
-
-        const maxLines = isMobile ? 3 : 5
-        const maxHeight = 32 * maxLines
-        textarea.style.height = Math.min(textarea.scrollHeight, maxHeight) + 'px'
-    }, [value, isMobile])
-
     return (
-        <div
-            className={`
-                flex flex-col w-[240px] tablet:w-[540px] desktop:w-[744px] p-4 space-y-6
-                border placeholder-gray-600 bg-neutral-white-opacity10 rounded-2xl
-                transition duration-300 ${isFocused ? 'border-gray-400' : 'border-transparent'}    
-            `}
-        >
-            <textarea
-                ref={textareaRef}
-                id={id}
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-                onFocus={() => setIsFocused(true)}
-                onBlur={() => setIsFocused(false)}
-                rows={isMobile ? 1 : 3}
-                placeholder={placeholder}
-                className="
-                    w-full h-fit max-h-[65px] tablet:max-h-[120px] tablet:px-2 outline-none resize-none focus:placeholder-transparent
-                    text-[14px] leading-[150%] tracking-[-0.35px] tablet:text-[16px] tablet:tracking-[-0.4px]
-                    whitespace-pre-line desktop:whitespace-nowrap
-                "
-            />
-
+        <Textarea id={id} value={value} onChange={onChange} placeholder={placeholder} initialRows={initialRows}>
             <div className="flex justify-end">
-                <ArrowButton type={buttonType} isActive={isActive} className="w-10 h-10" />
+                <ArrowButton type={buttonType} onClick={handleButtonClick} isActive={isActive} className="w-10 h-10" />
             </div>
-        </div>
+        </Textarea>
     )
 }
 


### PR DESCRIPTION
## 💡 Related Issue

closed #36 

## ✅ Summary

textarea 박스가 화살표 버튼이 필요한 것과 그러지 않은 것이 있는 이슈가 발견되었기 때문에 화살표 버튼이 있는 `TextareaWithArrow`와 없는 일반 `Textarea` 컴포넌트로 분리합니다.

## 📝 Description

### Textarea

- [x] 기본 `Textarea` 컴포넌트를 만들었습니다.
```
// 사용 예시
<Textarea
    id="channel-concept"
    value={text}
    onChange={setText}
    placeholder={`유튜버님의 채널 컨셉에 대한 설명을 입력해주세요.`}
    initialRows={3}
/>
```
<img width="801" height="179" alt="image" src="https://github.com/user-attachments/assets/f904058d-a02f-4065-a6ae-afe6421144d9" />

- 기본 height는 row 1줄이 들어가는 정도인데, `initialRows` 를 설정하면 사진처럼 높이를 늘릴 수 있어요.

---

### TextareaWithArrow 

- [x] 화살표 버튼이 있는 `TextareaWithArrow` 컴포넌트를 새롭게 구현했습니다.
```
// 사용 예시
<TextareaWithArrow
    id="viewer-target"
    value={text}
    onChange={setText}
    placeholder="정확한 분석을 위해 유튜버님의 시청자 타겟에 대한 설명을 입력해주세요. (예: 20대, 여성)"
    isActive={true}
    handleButtonClick={handleSubmit}
/>
```

## 💬 리뷰 요구 사항

이 부분은 특히나 수정 사항이 많아서 (props의 수정이 많아서) 해당 컴포넌트를 사용하신 분은 머지 후에 **코드에 오류가 없는지, 사용에 이상이 없는지**를 꼭 확인해 주세요!

<img width="2879" height="1594" alt="image" src="https://github.com/user-attachments/assets/a382f767-2269-440e-b011-8be50d6936ea" />

가로 스크롤이 생기는 이슈는 아직 해결이 안 된 것 같습니다?