### PR TITLE
[FIX] 저장소 페이지 스타일링 수정

### DIFF
--- a/frontend/src/components/common/Navbar/NavbarDesktop.tsx
+++ b/frontend/src/components/common/Navbar/NavbarDesktop.tsx
@@ -7,28 +7,27 @@ import { PLUS_LINK, NAVIGATE_LINKS, LOGIN_LINK } from './navbarLinks'
 import ChannelingLogo from '../../../assets/icons/channeling.svg?react'
 import { NavbarUserInfo } from './NavbarUserInfo'
 import { DUMMY_USER } from './dummy'
+import { useNavbarModals } from '../../../hooks/main/navbar/useNavbarModal'
 import { ChannelConceptModal, LoginModal, UrlInputModal, ViewerModal } from '../../../pages/main/_components'
 
 type ToolTipPos = { top: number; left: number }
 
 export const NavbarDesktop = () => {
-    const [showLoginModal, setShowLoginModal] = useState(false)
-    const [showViewerModal, setShowViewerModal] = useState(false)
-    const [showChannelConceptModal, setShowChannelConceptModal] = useState(false)
-
-    const [viewerValue, setViewerValue] = useState('')
-    const [channelConceptValue, setChannelConceptValue] = useState('')
-
-    const handleViewerChange = (value: string) => {
-        setViewerValue(value)
-    }
-
-    const handleCloseLoginModal = () => setShowLoginModal(false)
-    const handleOpenViewerModal = () => setShowViewerModal(true)
-    const handleCloseViewerModal = () => setShowViewerModal(false)
-    const handleOpenChannelConceptModal = () => setShowChannelConceptModal(true)
-    const handleCloseChannelConceptModal = () => setShowChannelConceptModal(false)
-    const handleChangeChannelConcept = (value: string) => setChannelConceptValue(value)
+    const {
+        showLoginModal,
+        showViewerModal,
+        showChannelConceptModal,
+        viewerValue,
+        channelConceptValue,
+        openLoginModal,
+        closeLoginModal,
+        openViewerModal,
+        closeViewerModal,
+        openChannelConceptModal,
+        closeChannelConceptModal,
+        changeViewerValue,
+        changeChannelConceptValue,
+    } = useNavbarModals()
 
     const [showPlusModal, setShowPlusModal] = useState(false)
     const isGuest = !localStorage.getItem('token')
@@ -61,7 +60,6 @@ export const NavbarDesktop = () => {
         }
     }, [isGuest])
 
-    const handleLoginModalClick = () => setShowLoginModal(!showLoginModal)
     const handlePlusModalClick = () => setShowPlusModal(!showPlusModal)
 
     return (
@@ -89,7 +87,7 @@ export const NavbarDesktop = () => {
                         {!isGuest && user ? (
                             <NavbarUserInfo user={DUMMY_USER} />
                         ) : (
-                            <NavbarModalButton key={LOGIN_LINK.alt} {...LOGIN_LINK} onClick={handleLoginModalClick} />
+                            <NavbarModalButton key={LOGIN_LINK.alt} {...LOGIN_LINK} onClick={openLoginModal} />
                         )}
                     </div>
 
@@ -104,30 +102,32 @@ export const NavbarDesktop = () => {
 
             {showLoginModal && (
                 <LoginModal
-                    onClose={handleCloseLoginModal}
+                    onClose={closeLoginModal}
                     onLoginSuccess={() => {
-                        handleCloseLoginModal()
-                        handleOpenViewerModal()
+                        changeViewerValue('')
+                        closeLoginModal()
+                        openViewerModal()
                     }}
                 />
             )}
             {showViewerModal && (
                 <ViewerModal
-                    onClose={handleCloseViewerModal}
+                    onClose={closeViewerModal}
                     value={viewerValue}
-                    onChange={handleViewerChange}
+                    onChange={changeViewerValue}
                     handleButtonClick={() => {
-                        handleCloseViewerModal()
-                        handleOpenChannelConceptModal()
+                        changeChannelConceptValue('')
+                        closeViewerModal()
+                        openChannelConceptModal()
                     }}
                 />
             )}
             {showChannelConceptModal && (
                 <ChannelConceptModal
-                    onClose={handleCloseChannelConceptModal}
+                    onClose={closeChannelConceptModal}
                     value={channelConceptValue}
-                    handleButtonClick={handleCloseChannelConceptModal}
-                    onChange={handleChangeChannelConcept}
+                    handleButtonClick={closeChannelConceptModal}
+                    onChange={changeChannelConceptValue}
                 />
             )}
 

--- a/frontend/src/hooks/main/navbar/useNavbarModal.ts
+++ b/frontend/src/hooks/main/navbar/useNavbarModal.ts
@@ -1,0 +1,43 @@
+import { useState } from 'react'
+
+export function useNavbarModals() {
+    const [showLoginModal, setShowLoginModal] = useState(false)
+    const [showViewerModal, setShowViewerModal] = useState(false)
+    const [showChannelConceptModal, setShowChannelConceptModal] = useState(false)
+
+    const [viewerValue, setViewerValue] = useState('')
+    const [channelConceptValue, setChannelConceptValue] = useState('')
+
+    const openLoginModal = () => setShowLoginModal(true)
+    const closeLoginModal = () => setShowLoginModal(false)
+
+    const openViewerModal = () => setShowViewerModal(true)
+    const closeViewerModal = () => setShowViewerModal(false)
+
+    const openChannelConceptModal = () => setShowChannelConceptModal(true)
+    const closeChannelConceptModal = () => setShowChannelConceptModal(false)
+
+    const changeViewerValue = (value: string) => setViewerValue(value)
+    const changeChannelConceptValue = (value: string) => setChannelConceptValue(value)
+
+    return {
+        // 상태값
+        showLoginModal,
+        showViewerModal,
+        showChannelConceptModal,
+        viewerValue,
+        channelConceptValue,
+
+        // 열기/닫기 핸들러
+        openLoginModal,
+        closeLoginModal,
+        openViewerModal,
+        closeViewerModal,
+        openChannelConceptModal,
+        closeChannelConceptModal,
+
+        // 입력값 핸들러
+        changeViewerValue,
+        changeChannelConceptValue,
+    }
+}

--- a/frontend/src/pages/library/LibraryPage.tsx
+++ b/frontend/src/pages/library/LibraryPage.tsx
@@ -84,9 +84,9 @@ export default function LibraryPage() {
                 className={
                     activeTab === 'report'
                         ? subTab === 'video'
-                            ? 'grid grid-cols-2 tablet:grid-cols-4 gap-6'
-                            : 'grid grid-cols-3 tablet:grid-cols-6 gap-3'
-                        : 'grid grid-cols-1 tablet:grid-cols-1 gap-6'
+                            ? 'grid grid-cols-2 desktop:grid-cols-4 gap-6'
+                            : 'grid grid-cols-3 desktop:grid-cols-6 gap-3'
+                        : 'grid grid-cols-1 desktop:grid-cols-1 gap-6'
                 }
             >
                 {filteredList.map((item) =>

--- a/frontend/src/pages/library/LibraryPage.tsx
+++ b/frontend/src/pages/library/LibraryPage.tsx
@@ -21,47 +21,60 @@ export default function LibraryPage() {
     }, [activeTab, subTab])
 
     return (
-        <div className="px-6 py-20 min-h-screen">
+        <div className="px-[76px] py-20">
             <div className="relative flex mb-6">
                 <button
-                    className={`flex-1 cursor-pointer pb-3.5 text-center text-[20px] font-bold leading-[28px] tracking-[-0.5px] relative ${
-                        activeTab === 'report' ? 'text-primary-500' : 'text-gray-600'
-                    }`}
+                    className={`flex-1 cursor-pointer pb-3.5 text-center text-[20px] font-bold 
+                        leading-[28px] tracking-[-0.5px] relative transition-colors duration-300 ${
+                            activeTab === 'report' ? 'text-primary-500' : 'text-gray-600'
+                        }`}
                     onClick={() => setActiveTab('report')}
                 >
                     최근 받아본 리포트
+                    <span className="absolute bottom-0 left-0 w-full h-1 bg-gray-600"></span>
                     {activeTab === 'report' && (
-                        <span className="absolute left-0 bottom-0 h-1 w-full bg-primary-500 z-10"></span>
+                        <span
+                            className="absolute left-0 bottom-0 h-1 w-full bg-primary-500 
+                        z-10 transition-all duration-300"
+                        ></span>
                     )}
                 </button>
+
                 <button
-                    className={`flex-1 cursor-pointer pb-3.5 text-center text-[20px] font-bold leading-[28px] tracking-[-0.5px] relative ${
-                        activeTab === 'scrap' ? 'text-primary-500' : 'text-gray-600'
-                    }`}
+                    className={`flex-1 cursor-pointer pb-3.5 text-center text-[20px] font-bold 
+                        leading-[28px] tracking-[-0.5px] relative transition-colors duration-300 ${
+                            activeTab === 'scrap' ? 'text-primary-500' : 'text-gray-600'
+                        }`}
                     onClick={() => setActiveTab('scrap')}
                 >
                     저장한 아이디어
+                    <span className="absolute bottom-0 left-0 w-full h-1 bg-gray-600"></span>
                     {activeTab === 'scrap' && (
-                        <span className="absolute left-0 bottom-0 h-1 w-full bg-primary-500 z-10"></span>
+                        <span
+                            className="absolute left-0 bottom-0 h-1 w-full bg-primary-500 
+                        z-10 transition-all duration-300"
+                        ></span>
                     )}
                 </button>
-                <span className="absolute bottom-0 left-0 w-full h-1 bg-gray-600"></span>
             </div>
+
             {activeTab === 'report' && (
                 <div className="flex justify-between items-center ">
                     <div className="flex gap-2 mb-6">
                         <button
-                            className={`px-4 cursor-pointer py-2 rounded-lg font-bold leading-[24px] tracking-[-0.4px] ${
-                                subTab === 'video' ? 'bg-primary-500 ' : 'bg-gray-100 '
-                            }`}
+                            className={`px-4 cursor-pointer py-2 rounded-lg font-bold leading-[24px] 
+                                tracking-[-0.4px] transition-all duration-300 ${
+                                    subTab === 'video' ? 'bg-primary-500 ' : 'bg-gray-100 '
+                                }`}
                             onClick={() => setSubTab('video')}
                         >
                             동영상
                         </button>
                         <button
-                            className={`px-4 cursor-pointer py-2 rounded-lg font-bold leading-[24px] tracking-[-0.4px] ${
-                                subTab === 'shorts' ? 'bg-primary-500' : 'bg-gray-100'
-                            }`}
+                            className={`px-4 cursor-pointer py-2 rounded-lg font-bold leading-[24px] 
+                                tracking-[-0.4px] transition-all duration-300 ${
+                                    subTab === 'shorts' ? 'bg-primary-500' : 'bg-gray-100'
+                                }`}
                             onClick={() => setSubTab('shorts')}
                         >
                             Shorts

--- a/frontend/src/pages/library/LibraryPage.tsx
+++ b/frontend/src/pages/library/LibraryPage.tsx
@@ -24,7 +24,7 @@ export default function LibraryPage() {
         <div className="px-6 py-20 min-h-screen">
             <div className="relative flex mb-6">
                 <button
-                    className={`flex-1 pb-3.5 text-center text-[20px] font-bold leading-[28px] tracking-[-0.5px] relative ${
+                    className={`flex-1 cursor-pointer pb-3.5 text-center text-[20px] font-bold leading-[28px] tracking-[-0.5px] relative ${
                         activeTab === 'report' ? 'text-primary-500' : 'text-gray-600'
                     }`}
                     onClick={() => setActiveTab('report')}
@@ -35,7 +35,7 @@ export default function LibraryPage() {
                     )}
                 </button>
                 <button
-                    className={`flex-1 pb-3.5 text-center text-[20px] font-bold leading-[28px] tracking-[-0.5px] relative ${
+                    className={`flex-1 cursor-pointer pb-3.5 text-center text-[20px] font-bold leading-[28px] tracking-[-0.5px] relative ${
                         activeTab === 'scrap' ? 'text-primary-500' : 'text-gray-600'
                     }`}
                     onClick={() => setActiveTab('scrap')}
@@ -51,7 +51,7 @@ export default function LibraryPage() {
                 <div className="flex justify-between items-center ">
                     <div className="flex gap-2 mb-6">
                         <button
-                            className={`px-4 py-2 rounded-lg font-bold leading-[24px] tracking-[-0.4px] ${
+                            className={`px-4 cursor-pointer py-2 rounded-lg font-bold leading-[24px] tracking-[-0.4px] ${
                                 subTab === 'video' ? 'bg-primary-500 ' : 'bg-gray-100 '
                             }`}
                             onClick={() => setSubTab('video')}
@@ -59,7 +59,7 @@ export default function LibraryPage() {
                             동영상
                         </button>
                         <button
-                            className={`px-4 py-2 rounded-lg font-bold leading-[24px] tracking-[-0.4px] ${
+                            className={`px-4 cursor-pointer py-2 rounded-lg font-bold leading-[24px] tracking-[-0.4px] ${
                                 subTab === 'shorts' ? 'bg-primary-500' : 'bg-gray-100'
                             }`}
                             onClick={() => setSubTab('shorts')}

--- a/frontend/src/pages/library/_components/RecentReportCard.tsx
+++ b/frontend/src/pages/library/_components/RecentReportCard.tsx
@@ -1,12 +1,18 @@
 import { memo } from 'react'
 import type { LibraryItem } from '../../../types/library'
+import { X } from 'lucide-react'
 
 export default memo(function RecentReportCard({ item }: { item: LibraryItem }) {
     return (
-        <div className="rounded-lg overflow-hidden bg-transparent ">
-            <p className="text-sm font-normal leading-[19.6px] tracking-[-0.35px] text-gray-600">
-                업데이트 : {item.updatedAt}
-            </p>
+        <div className="relative group rounded-lg overflow-hidden bg-transparent ">
+            <div className="flex items-center justify-between">
+                <p className="text-sm font-normal leading-[19.6px] tracking-[-0.35px] text-gray-600">
+                    업데이트 : {item.updatedAt}
+                </p>
+                <button className="absolute w-6 h-6 -right-[4px] hidden group-hover:block ">
+                    <X className="w-full h-full fill-gray-900 " />
+                </button>
+            </div>
 
             <img src={item.thumbnail} alt={item.title} className="w-full aspect-video object-cover mt-2 mb-2" />
 

--- a/frontend/src/pages/library/_components/RecentReportCard.tsx
+++ b/frontend/src/pages/library/_components/RecentReportCard.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react'
 import type { LibraryItem } from '../../../types/library'
-import { X } from 'lucide-react'
+import X from '../../../assets/icons/X.svg?react'
 
 export default memo(function RecentReportCard({ item }: { item: LibraryItem }) {
     return (

--- a/frontend/src/pages/library/_components/RecentReportShortsCard.tsx
+++ b/frontend/src/pages/library/_components/RecentReportShortsCard.tsx
@@ -9,7 +9,7 @@ export default memo(function RecentReportShortsCard({ item }: { item: LibraryIte
                 <p className="text-sm font-normal leading-[19.6px] tracking-[-0.35px] text-gray-600">
                     업데이트 : {item.updatedAt}
                 </p>
-                <button className="absolute w-6 h-6 -right-[4px] hidden group-hover:block ">
+                <button className="absolute w-6 h-6 -right-[4px] hidden group-hover:block  ">
                     <X className="w-full h-full fill-gray-900 " />
                 </button>
             </div>

--- a/frontend/src/pages/library/_components/RecentReportShortsCard.tsx
+++ b/frontend/src/pages/library/_components/RecentReportShortsCard.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react'
 import type { LibraryItem } from '../../../types/library'
-import { X } from 'lucide-react'
+import X from '../../../assets/icons/X.svg?react'
 
 export default memo(function RecentReportShortsCard({ item }: { item: LibraryItem }) {
     return (

--- a/frontend/src/pages/library/_components/RecentReportShortsCard.tsx
+++ b/frontend/src/pages/library/_components/RecentReportShortsCard.tsx
@@ -1,12 +1,18 @@
 import { memo } from 'react'
 import type { LibraryItem } from '../../../types/library'
+import { X } from 'lucide-react'
 
 export default memo(function RecentReportShortsCard({ item }: { item: LibraryItem }) {
     return (
-        <div className=" rounded-lg bg-cover bg-center overflow-hidden bg-transparent">
-            <p className="text-sm font-normal leading-[19.6px] tracking-[-0.35px] text-gray-600">
-                업데이트 : {item.updatedAt}
-            </p>
+        <div className="relative group rounded-lg overflow-hidden bg-transparent">
+            <div className="flex items-center justify-between">
+                <p className="text-sm font-normal leading-[19.6px] tracking-[-0.35px] text-gray-600">
+                    업데이트 : {item.updatedAt}
+                </p>
+                <button className="absolute w-6 h-6 -right-[4px] hidden group-hover:block ">
+                    <X className="w-full h-full fill-gray-900 " />
+                </button>
+            </div>
 
             <img src={item.thumbnail} alt={item.title} className="w-full aspect-[192/289] object-cover mt-2 mb-2" />
 

--- a/frontend/src/pages/library/_components/ScrapCard.tsx
+++ b/frontend/src/pages/library/_components/ScrapCard.tsx
@@ -6,7 +6,7 @@ export default memo(function ScrapCard({ item }: { item: ScrapItem }) {
     const [isFilled, setIsFilled] = useState(true) // true면 채워짐
 
     return (
-        <div className="relative w-full p-5 rounded-lg bg-gray-100 hover:shadow transition">
+        <div className="relative w-full p-5 rounded-lg border border-gray-200 bg-gray-100 hover:bg-gray-200 transition">
             <Bookmark
                 className="absolute top-5 right-5 w-5 h-5 cursor-pointer text-primary-500"
                 fill={isFilled ? 'var(--color-primary-500)' : 'none'}

--- a/frontend/src/pages/library/_components/ScrapCard.tsx
+++ b/frontend/src/pages/library/_components/ScrapCard.tsx
@@ -1,5 +1,6 @@
 import { memo, useState } from 'react'
-import { Bookmark } from 'lucide-react'
+import Bookmark from '../../../assets/icons/bookmark.svg?react'
+import BookmarkActive from '../../../assets/icons/bookmark_active.svg?react'
 import type { ScrapItem } from '../../../types/library'
 
 export default memo(function ScrapCard({ item }: { item: ScrapItem }) {
@@ -7,13 +8,14 @@ export default memo(function ScrapCard({ item }: { item: ScrapItem }) {
 
     return (
         <div className="relative w-full p-5 rounded-lg border border-gray-200 bg-gray-100 hover:bg-gray-200 duration-300 transition">
-            <Bookmark
-                className="absolute top-5 right-5 w-5 h-5 cursor-pointer text-primary-500"
-                fill={isFilled ? 'var(--color-primary-500)' : 'none'}
-                stroke="currentColor"
-                strokeWidth={2}
-                onClick={() => setIsFilled(!isFilled)}
-            />
+            {isFilled ? (
+                <BookmarkActive
+                    className="absolute top-5 right-5 w-5 h-5 cursor-pointer"
+                    onClick={() => setIsFilled(false)}
+                />
+            ) : (
+                <Bookmark className="absolute top-5 right-5 w-5 h-5 cursor-pointer" onClick={() => setIsFilled(true)} />
+            )}
 
             <h3 className="text-[20px] font-bold leading-[28px] tracking-[-0.5px] mb-2 flex items-center gap-2">
                 <span>코케트(coquette) 패션 인사</span>

--- a/frontend/src/pages/library/_components/ScrapCard.tsx
+++ b/frontend/src/pages/library/_components/ScrapCard.tsx
@@ -6,7 +6,7 @@ export default memo(function ScrapCard({ item }: { item: ScrapItem }) {
     const [isFilled, setIsFilled] = useState(true) // true면 채워짐
 
     return (
-        <div className="relative w-full p-5 rounded-lg border border-gray-200 bg-gray-100 hover:bg-gray-200 transition">
+        <div className="relative w-full p-5 rounded-lg border border-gray-200 bg-gray-100 hover:bg-gray-200 duration-300 transition">
             <Bookmark
                 className="absolute top-5 right-5 w-5 h-5 cursor-pointer text-primary-500"
                 fill={isFilled ? 'var(--color-primary-500)' : 'none'}


### PR DESCRIPTION
## 💡 Related Issue

- close #66 

## ✅ Summary

피드백 주신 내용 수정했습니다.
1. 반응형 그리드 피그마와 일치하지 않습니다. → Shorts 탭도 확인 후 수정 필요 (Tablet 사이즈에서 반응형 수정)
2. hover시 스타일 변화 기능 개발되어 있지 않습니다. (cursor-pointer 추가, 호버 기능 및 활성화 탭 이동에 transition duration-300 애니메이션 추가)
3. 전체 페이지 x축 패딩 값 피그마와 일치하지 않습니다.

## 📝 Description

1번 내용
<img width="1476" height="1566" alt="image" src="https://github.com/user-attachments/assets/2e5a510d-4de1-4374-9546-333a9b6459fa" />
2번 내용
<img width="2879" height="1623" alt="image" src="https://github.com/user-attachments/assets/2359f4ec-6051-4776-8e18-5563f1febb93" />
3번 내용
<img width="2879" height="1626" alt="image" src="https://github.com/user-attachments/assets/7fff0a7f-07df-4f0e-a8c1-04b9c233348c" />

