### PR TITLE
[DEV] 메인 페이지 화면 설계서에 맞춰 기능 보완

### DIFF
--- a/frontend/src/components/ScrollToTop.tsx
+++ b/frontend/src/components/ScrollToTop.tsx
@@ -1,0 +1,17 @@
+import { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
+
+export default function ScrollToTop() {
+    const { pathname } = useLocation()
+
+    useEffect(() => {
+        const scrollContainer = document.getElementById('scroll-container')
+        if (scrollContainer) {
+            scrollContainer.scrollTop = 0
+        } else {
+            window.scrollTo(0, 0)
+        }
+    }, [pathname])
+
+    return null
+}

--- a/frontend/src/components/common/Navbar/NavbarDesktop.tsx
+++ b/frontend/src/components/common/Navbar/NavbarDesktop.tsx
@@ -8,6 +8,7 @@ import ChannelingLogo from '../../../assets/icons/channeling.svg?react'
 import { NavbarUserInfo } from './NavbarUserInfo'
 import { DUMMY_USER } from './dummy'
 import { ChannelConceptModal, LoginModal, UrlInputModal, ViewerModal } from '../../../pages/main/_components'
+import { useAuthStore } from '../../../stores/authStore'
 
 type ToolTipPos = { top: number; left: number }
 
@@ -31,8 +32,8 @@ export const NavbarDesktop = () => {
     const handleChangeChannelConcept = (value: string) => setChannelConceptValue(value)
 
     const [showPlusModal, setShowPlusModal] = useState(false)
-    const isGuest = !localStorage.getItem('token')
-    const user = DUMMY_USER
+    const isAuth = useAuthStore((state) => state.isAuth) // ✅ 임시
+    const user = DUMMY_USER // ✅ 임시
 
     const loginRef = useRef<HTMLDivElement>(null)
     const [tooltipPos, setTooltipPos] = useState<ToolTipPos | null>(null)
@@ -40,7 +41,7 @@ export const NavbarDesktop = () => {
     // 로그인 툴팁 위치 조정
     useEffect(() => {
         const updateTooltipPosition = () => {
-            if (isGuest && loginRef.current) {
+            if (!isAuth && loginRef.current) {
                 const rect = loginRef.current.getBoundingClientRect()
                 setTooltipPos({
                     top: rect.top + window.scrollY,
@@ -59,7 +60,7 @@ export const NavbarDesktop = () => {
             window.removeEventListener('scroll', updateTooltipPosition)
             window.removeEventListener('resize', updateTooltipPosition)
         }
-    }, [isGuest])
+    }, [isAuth])
 
     const handleLoginModalClick = () => setShowLoginModal(!showLoginModal)
     const handlePlusModalClick = () => setShowPlusModal(!showPlusModal)
@@ -86,7 +87,7 @@ export const NavbarDesktop = () => {
 
                     {/* 로그인 버튼 혹은 유저 프로필 */}
                     <div ref={loginRef} className="flex flex-col items-center">
-                        {!isGuest && user ? (
+                        {isAuth && user ? (
                             <NavbarUserInfo user={DUMMY_USER} />
                         ) : (
                             <NavbarModalButton key={LOGIN_LINK.alt} {...LOGIN_LINK} onClick={handleLoginModalClick} />
@@ -94,7 +95,7 @@ export const NavbarDesktop = () => {
                     </div>
 
                     {/* 게스트일 경우, 10초만에 로그인 툴팁 */}
-                    {isGuest && tooltipPos && (
+                    {!isAuth && tooltipPos && (
                         <div style={{ position: 'absolute', top: tooltipPos.top, left: tooltipPos.left }}>
                             <ToolTipBubble />
                         </div>

--- a/frontend/src/pages/layouts/RootLayout.tsx
+++ b/frontend/src/pages/layouts/RootLayout.tsx
@@ -1,6 +1,7 @@
 import { Outlet, useLocation } from 'react-router-dom'
 import { NavbarWrapper } from '../../components/common/Navbar/NavbarWrapper'
 import ReportLoadingSpinner from '../../components/ReportLoadingSpinner'
+import ScrollToTop from '../../components/ScrollToTop'
 
 export default function RootLayout() {
     const location = useLocation()
@@ -22,12 +23,14 @@ export default function RootLayout() {
                     <div className="absolute inset-0 z-0 bg-gradient-to-b from-gray-50 to-primary-50" />
 
                     <div
+                        id="scroll-container"
                         className={`
                             relative z-10 w-full h-full overflow-y-auto [&::-webkit-scrollbar]:hidden
                             bg-linear-to-b from-gray-50 to-primary-50 
                             ${!isMain && 'desktop:bg-none desktop:bg-gray-50'}
                         `}
                     >
+                        <ScrollToTop />
                         <Outlet />
                     </div>
                 </div>

--- a/frontend/src/pages/main/MainPage.tsx
+++ b/frontend/src/pages/main/MainPage.tsx
@@ -10,12 +10,13 @@ export default function MainPage() {
         <div className="flex flex-col items-center justify-center z-50">
             <div
                 className="
-                    flex flex-col items-center justify-center mb-[222px] tablet:mb-[324px] desktop:mb-[84px]
+                    flex flex-col items-center justify-center 
+                    mt-[100px] tablet:mt-60 desktop:mt-80 mb-[222px] tablet:mb-[324px] desktop:mb-[84px]
                     space-y-4 tablet:space-y-6 whitespace-pre-line tablet:whitespace-
                 "
             >
                 <h1
-                    className="mt-[100px] tablet:mt-60 desktop:mt-80
+                    className="
                         text-center text-[18px] leading-[150%] font-bold tracking-[-0.45px] tablet:text-[20px] tablet:leading-[140%] tablet:tracking-[-0.5px]
                         whitespace-pre-line tablet:whitespace-nowrap
                     "

--- a/frontend/src/pages/main/MainPage.tsx
+++ b/frontend/src/pages/main/MainPage.tsx
@@ -1,8 +1,11 @@
 import { Footer } from '../../components/common/Footer'
+import { useAuthStore } from '../../stores/authStore'
 import { UrlInputForm, VideoRecommendation } from './_components'
 import { DUMMY_MY, DUMMY_POPULAR } from './dummy'
 
 export default function MainPage() {
+    const isAuth = useAuthStore((state) => state.isAuth)
+
     return (
         <div className="flex flex-col items-center justify-center z-50">
             <div
@@ -23,7 +26,7 @@ export default function MainPage() {
                 <UrlInputForm />
 
                 <div className="space-y-20 tablet:space-y-10">
-                    <VideoRecommendation label="내 영상의 개선점을 알고 싶다면" videos={DUMMY_MY} />
+                    {isAuth && <VideoRecommendation label="내 영상의 개선점을 알고 싶다면" videos={DUMMY_MY} />}
                     <VideoRecommendation label="인기있는 영상의 비결은?" videos={DUMMY_POPULAR} />
                 </div>
             </div>

--- a/frontend/src/pages/main/_components/UrlInputForm.tsx
+++ b/frontend/src/pages/main/_components/UrlInputForm.tsx
@@ -7,6 +7,8 @@ import ArrowButton from '../../../components/ArrowButton'
 import { ErrorToast } from './ErrorToast'
 import ErrorIcon from '../../../assets/icons/error.svg?react'
 import { useUrlInput } from '../../../hooks/main/useUrlInput'
+import Modal from '../../../components/Modal'
+import { useAuthStore } from '../../../stores/authStore'
 
 export const UrlInputForm = () => {
     const navigate = useNavigate()
@@ -15,14 +17,25 @@ export const UrlInputForm = () => {
     const startGenerating = useReportStore((state) => state.actions.startGenerating)
     const endGenerating = useReportStore((state) => state.actions.endGenerating)
 
+    const isAuth = useAuthStore((state) => state.isAuth)
+
+    // ✅ 임시 로그인 모달 열림 상태
+    const setAuthMember = useAuthStore((state) => state.actions.setAuthMember)
+    const [isOpen, setIsOpen] = useState(false)
+
     const { register, handleSubmit, isActive, error, setError } = useUrlInput((url) => {
         console.log('메인 페이지에서 받은 URL:', url)
 
-        startGenerating()
-        setTimeout(() => {
-            endGenerating()
-            navigate('/report')
-        }, 5000)
+        if (isAuth) {
+            startGenerating()
+            setTimeout(() => {
+                endGenerating()
+                navigate('/report/1') // ✅ 임시 네비게이션: API 연결시 응답 영상 id로 수정 필요
+            }, 5000)
+        } else {
+            // ✅ 임시 비로그인 로직
+            setIsOpen(true)
+        }
     })
 
     return (
@@ -84,6 +97,17 @@ export const UrlInputForm = () => {
 
             {/* 입력 에러 토스트 */}
             {error && <ErrorToast errorMessage={error} />}
+
+            {/* ✅ 임시 로그인 모달 */}
+            {isOpen && (
+                <Modal
+                    title="임시 로그인 모달"
+                    onClose={() => {
+                        setAuthMember()
+                        setIsOpen(false)
+                    }}
+                />
+            )}
         </>
     )
 }

--- a/frontend/src/pages/main/_components/UrlInputModal.tsx
+++ b/frontend/src/pages/main/_components/UrlInputModal.tsx
@@ -6,6 +6,9 @@ import { useReportStore } from '../../../stores/reportStore'
 import ArrowButton from '../../../components/ArrowButton'
 import ErrorIcon from '../../../assets/icons/error.svg?react'
 import { useUrlInput } from '../../../hooks/main/useUrlInput'
+import { ErrorToast } from './ErrorToast'
+import { useAuthStore } from '../../../stores/authStore'
+import Modal from '../../../components/Modal'
 
 interface UrlInputModalProps {
     onClose: () => void
@@ -19,15 +22,26 @@ export const UrlInputModal = ({ onClose }: UrlInputModalProps) => {
     const startGenerating = useReportStore((state) => state.actions.startGenerating)
     const endGenerating = useReportStore((state) => state.actions.endGenerating)
 
+    const isAuth = useAuthStore((state) => state.isAuth)
+
+    // ✅ 임시 로그인 모달 열림 상태
+    const setAuthMember = useAuthStore((state) => state.actions.setAuthMember)
+    const [isOpen, setIsOpen] = useState(false)
+
     const { register, handleSubmit, isActive, error, setError } = useUrlInput((url) => {
         console.log('모달에서 받은 URL:', url)
 
-        startGenerating()
-        setTimeout(() => {
-            endGenerating()
-            onClose()
-            navigate('/report')
-        }, 5000)
+        if (isAuth) {
+            startGenerating()
+            setTimeout(() => {
+                endGenerating()
+                onClose()
+                navigate('/report/1') // ✅ 임시 네비게이션: API 연결시 응답 영상 id로 수정 필요
+            }, 5000)
+        } else {
+            // ✅ 임시 비로그인 로직
+            setIsOpen(true)
+        }
     })
 
     // ESC 키로 모달 창 닫기
@@ -106,6 +120,20 @@ export const UrlInputModal = ({ onClose }: UrlInputModalProps) => {
                     {error}
                 </p>
             </div>
+
+            {/* 입력 에러 토스트 */}
+            {error && <ErrorToast errorMessage={error} />}
+
+            {/* ✅ 임시 로그인 모달 */}
+            {isOpen && (
+                <Modal
+                    title="임시 로그인 모달"
+                    onClose={() => {
+                        setAuthMember()
+                        setIsOpen(false)
+                    }}
+                />
+            )}
         </div>
     )
 }

--- a/frontend/src/pages/main/_components/VideoCard.tsx
+++ b/frontend/src/pages/main/_components/VideoCard.tsx
@@ -1,13 +1,18 @@
 import type { DUMMY_MY } from '../dummy'
 import { formatRelativeTime, formatKoreanNumber } from '../../../utils/format'
+import { Link } from 'react-router-dom'
+import { useAuthStore } from '../../../stores/authStore'
 
 interface VideoCardProps {
     video: (typeof DUMMY_MY)[0] // 임시
 }
 
 export const VideoCard = ({ video }: VideoCardProps) => {
+    const isAuth = useAuthStore((state) => state.isAuth)
+    const linkTo = isAuth ? `/report/${video.id}` : '/report'
+
     return (
-        <div className="flex flex-col items-center justify-center gap-2 w-[288px] tablet:w-[282px]">
+        <Link to={linkTo} className="flex flex-col items-center justify-center gap-2 w-[288px] tablet:w-[282px]">
             {/* 영상 썸네일 이미지 */}
             <div className="w-[288px] aspect-[16/9] tablet:w-[282px] tablet:aspect-[141/79] rounded-lg overflow-hidden">
                 <img src={video.thumbnail} className="w-full h-full object-cover" />
@@ -33,6 +38,6 @@ export const VideoCard = ({ video }: VideoCardProps) => {
                     </div>
                 </div>
             </div>
-        </div>
+        </Link>
     )
 }

--- a/frontend/src/pages/main/dummy.ts
+++ b/frontend/src/pages/main/dummy.ts
@@ -1,17 +1,17 @@
 export const DUMMY_MY = [
     {
         id: 1,
-        title: '헬스터디 3: 최애의 수능 응원',
+        title: '저 드디어 독립했어요!',
         description: '',
-        channelId: 1,
-        channelTitle: '미미미누',
+        channelId: 2,
+        channelTitle: '찰스엔터',
         channelProfile:
-            'https://spangled-bridge-914.notion.site/image/attachment%3A7eb67923-ecc1-4552-87dc-5353e0029be5%3Aimage.png?table=block&id=22608691-8f43-804d-a067-cb0a9b30207b&spaceId=719616fc-abf0-4573-86e5-37abb50a4cfb&width=2000&userId=&cache=v2',
+            'https://yt3.googleusercontent.com/ytc/AIdro_l2dPj4s4Mx0qh3CarWH48OAAJ9Hxb7Hl8-crZSnFE8zA=s160-c-k-c0x00ffffff-no-rj',
         thumbnail:
-            'https://spangled-bridge-914.notion.site/image/attachment%3A98b7d8c1-b4cb-4d5d-b986-fafde4f6df5d%3Aimage.png?table=block&id=22608691-8f43-80b6-8012-f1c90b3b4ce2&spaceId=719616fc-abf0-4573-86e5-37abb50a4cfb&width=1130&userId=&cache=v2',
-        viewCount: 170_000,
-        likeCount: 1_300,
-        publishedAt: '2021-11-05T12:00:00Z',
+            'https://spangled-bridge-914.notion.site/image/attachment%3A77a4c727-0e03-4344-bab2-477fc4fc8dab%3Aimage.png?table=block&id=22a08691-8f43-8057-9906-f248115469bf&spaceId=719616fc-abf0-4573-86e5-37abb50a4cfb&width=1950&userId=&cache=v2',
+        viewCount: 1_920_000,
+        likeCount: 40_300,
+        publishedAt: '2025-05-21T12:00:00Z',
     },
     {
         id: 2,

--- a/frontend/src/pages/report/ReportPage.tsx
+++ b/frontend/src/pages/report/ReportPage.tsx
@@ -1,9 +1,11 @@
 import Tabs from '../../components/Tabs'
 import { TabOverview, TabAnalysis, TabIdea, VideoSummary, GuestModal } from './_components'
-import { VIDEO } from './dummy'
+import { AUTH_VIDEO, GUEST_VIDEO } from './dummy'
 import Refresh from '../../assets/icons/refresh_2.svg?react'
 import { useEffect, useState } from 'react'
 import Modal from '../../components/Modal'
+import { useAuthStore } from '../../stores/authStore'
+import { useParams } from 'react-router-dom'
 
 const TABS = [
     { index: 0, label: '개요', component: <TabOverview /> },
@@ -12,16 +14,24 @@ const TABS = [
 ]
 
 export default function ReportPage() {
+    const { reportId } = useParams()
+    const isAuth = useAuthStore((state) => state.isAuth)
+
     const [activeTab, setActiveTab] = useState(TABS[0])
     const [isOpenUpdateModal, setIsOpenUpdateModal] = useState(false)
     const [isOpenGuestModal, setIsOpenGuestModal] = useState(false) // 전역 상태 전환 필요
 
-    const video = VIDEO
+    // ✅ 임시 비디오 데이터 (API 연결시 수정)
+    let video
+    if (reportId) {
+        video = AUTH_VIDEO
+    } else {
+        video = GUEST_VIDEO
+    }
 
     useEffect(() => {
-        const isGuest = !localStorage.getItem('token')
-        setIsOpenGuestModal(isGuest)
-    }, [])
+        setIsOpenGuestModal(!isAuth)
+    }, [isAuth])
 
     const handleOpenUpdateModalClick = () => setIsOpenUpdateModal(!isOpenUpdateModal)
     const handleOpenGuestModalClick = () => setIsOpenGuestModal(!isOpenGuestModal)

--- a/frontend/src/pages/report/dummy.ts
+++ b/frontend/src/pages/report/dummy.ts
@@ -1,11 +1,13 @@
-export const VIDEO = {
+export const AUTH_VIDEO = {
     id: 1,
     title: '저 드디어 독립했어요!',
+    videoId: 'GHR8R9i0t4A',
+    // videoId: 'na3kswvVbq8',
     thumbnail:
         'https://spangled-bridge-914.notion.site/image/attachment%3A77a4c727-0e03-4344-bab2-477fc4fc8dab%3Aimage.png?table=block&id=22a08691-8f43-8057-9906-f248115469bf&spaceId=719616fc-abf0-4573-86e5-37abb50a4cfb&width=1950&userId=&cache=v2',
     tag: 'Long-form',
     channel: {
-        id: 1,
+        id: 2,
         title: '찰스엔터',
         profileImage:
             'https://spangled-bridge-914.notion.site/image/attachment%3A7eb67923-ecc1-4552-87dc-5353e0029be5%3Aimage.png?table=block&id=22608691-8f43-804d-a067-cb0a9b30207b&spaceId=719616fc-abf0-4573-86e5-37abb50a4cfb&width=2000&userId=&cache=v2',
@@ -13,6 +15,29 @@ export const VIDEO = {
     viewCount: 170_000,
     likeCount: 1_300,
     publishedAt: '2022-11-05T12:00:00+09:00',
+    report: {
+        createdAt: '2022-11-05T12:00:00+09:00',
+        updatedAt: '2025-06-21T03:39:00+09:00',
+    },
+}
+
+export const GUEST_VIDEO = {
+    id: 2,
+    title: `
+"수능 잘 보고 고려대에서 만나요" 헬스터디 학생들의 5월 학력평가 성적을 공개합니다 | 헬스터디3 EP.11`,
+    videoId: 'S_H2Re2li0A',
+    thumbnail:
+        'https://spangled-bridge-914.notion.site/image/attachment%3A98b7d8c1-b4cb-4d5d-b986-fafde4f6df5d%3Aimage.png?table=block&id=22608691-8f43-80b6-8012-f1c90b3b4ce2&spaceId=719616fc-abf0-4573-86e5-37abb50a4cfb&width=1130&userId=&cache=v2',
+    tag: 'Long-form',
+    channel: {
+        id: 1,
+        title: '미미미누',
+        profileImage:
+            'https://spangled-bridge-914.notion.site/image/attachment%3A7eb67923-ecc1-4552-87dc-5353e0029be5%3Aimage.png?table=block&id=22608691-8f43-804d-a067-cb0a9b30207b&spaceId=719616fc-abf0-4573-86e5-37abb50a4cfb&width=2000&userId=&cache=v2',
+    },
+    viewCount: 230_000,
+    likeCount: 3_600,
+    publishedAt: '2025-05-20T12:00:00+09:00',
     report: {
         createdAt: '2022-11-05T12:00:00+09:00',
         updatedAt: '2025-06-21T03:39:00+09:00',

--- a/frontend/src/router/router.tsx
+++ b/frontend/src/router/router.tsx
@@ -15,7 +15,7 @@ export const router = createBrowserRouter([
                 element: <MainPage />,
             },
             {
-                path: '/report',
+                path: '/report/:reportId?',
                 element: <ReportPage />,
             },
             {

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -1,0 +1,26 @@
+import { create } from 'zustand'
+import { devtools } from 'zustand/middleware'
+
+interface AuthActions {
+    setUser: (user: string) => void // 유저 정보 타입을 만들어서 수정 가능성
+    setAuthGuest: () => void
+    setAuthMember: () => void
+}
+
+interface AuthState {
+    user: string | null
+    isAuth: boolean
+    actions: AuthActions
+}
+
+export const useAuthStore = create<AuthState>()(
+    devtools((set) => ({
+        user: null,
+        isAuth: false,
+        actions: {
+            setUser: (user: string) => set({ user }),
+            setAuthGuest: () => set({ isAuth: false }),
+            setAuthMember: () => set({ isAuth: true }),
+        },
+    }))
+)


### PR DESCRIPTION
## 💡 Related Issue

closed #65 

## ✅ Summary

메인 페이지 화면 설계서에 맞춰 기능 플로우를 보완했습니다.

## 📝 Description

- [x] 링크 입력 필드 전송 클릭시
- 비로그인 상태: <로그인> 모달
- 로그인 상태: <리포트> 페이지로 이동
- 로그인 하고 돌아와도 입력 값 보존
- [x] [자신의 채널 영상 추천] 로그인 상태에서만 보임
- [x] 자신의 채널 영상 추천 클릭 시 <리포트> 페이지로 이동
- [x] 인기 영상 추천 클릭 시 더미 데이터의 <리포트> 페이지로 이동
- 리포트 페이지 Auth 여부에 따른 분리
