### PR TITLE
[FIX] 리포트 페이지 분석 탭 텍스트 스타일링 수정

### DIFF
--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -97,32 +97,44 @@
 }
 
 @layer components {
-    .font-title {
-        @apply text-[16px] leading-[140%] font-normal sm:text-[18px] sm:leading-[140%] sm:font-bold md:text-[20px] md:leading-[140%] md:font-bold;
+    .font-title-alt {
+        @apply text-[16px] leading-[140%] font-normal md:text-[24px] md:leading-[140%] md:font-bold;
     }
 
-    .font-title-alt {
-        @apply text-[16px] leading-[140%] font-normal sm:text-[18px] sm:leading-[140%] sm:font-bold md:text-[18px] md:leading-[140%] md:font-bold;
+    .font-title {
+        @apply text-[16px] leading-[140%] font-normal tracking-[-0.5px] md:text-[20px] md:leading-[140%] md:font-bold;
+    }
+
+    .font-title-medium {
+        @apply text-[16px] leading-[140%] font-normal md:text-[20px] md:leading-[140%] md:font-medium;
+    }
+
+    .font-title-bold {
+        @apply text-[16px] leading-[140%] font-normal tracking-[-0.45px] md:text-[18px] md:leading-[140%] md:font-bold;
     }
 
     .font-body {
-        @apply text-[14px] leading-[150%] font-bold sm:text-[24px] sm:leading-[150%] sm:font-medium md:text-[16px] md:leading-[150%] md:font-normal;
+        @apply text-[14px] leading-[150%] font-bold md:text-[16px] md:leading-[150%] md:font-normal;
     }
 
     .font-body-medium {
-        @apply text-[16px] leading-[150%] font-medium sm:text-[24px] sm:leading-[150%] sm:font-medium md:text-[16px] md:leading-[150%] md:font-medium;
+        @apply text-[16px] leading-[150%] font-medium tracking-[-0.4px] md:text-[16px] md:leading-[150%] md:font-medium;
     }
 
     .font-body-regular {
-        @apply text-[14px] leading-[150%] font-normal sm:text-[24px] sm:leading-[150%] sm:font-medium md:text-[16px] md:leading-[150%] md:font-normal;
+        @apply text-[14px] leading-[150%] font-normal tracking-[-0.4px] md:text-[16px] md:leading-[150%] md:font-normal;
     }
 
     .font-body-bold {
-        @apply text-[16px] leading-[150%] font-bold sm:text-[24px] sm:leading-[150%] sm:font-medium md:text-[16px] md:leading-[150%] md:font-bold;
+        @apply text-[16px] leading-[150%] font-bold tracking-[-0.4px] md:text-[16px] md:leading-[150%] md:font-bold;
     }
 
     .font-caption {
-        @apply text-[12px] leading-[140%] font-normal tracking-tight sm:text-[14px] sm:leading-[140%] sm:font-normal md:text-[14px] md:leading-[140%] md:font-normal;
+        @apply text-[12px] leading-[140%] font-normal tracking-[-0.35px] md:text-[14px] md:leading-[140%] md:font-normal;
+    }
+
+    .font-caption-medium {
+        @apply text-[12px] leading-[140%] font-normal tracking-[-0.35px] md:text-[14px] md:leading-[140%] md:font-medium;
     }
 }
 

--- a/frontend/src/pages/report/_components/analysis/AlgorithmOptimization.tsx
+++ b/frontend/src/pages/report/_components/analysis/AlgorithmOptimization.tsx
@@ -11,21 +11,15 @@ export const AlgorithmOptimization = () => {
                 className="w-full rounded-lg border border-gray-200
                             bg-surface-elevate-l1 p-6 overflow-y-auto overflow-hidden"
             >
-                <div className="flex flex-col space-y-4 font-body-regular tracking-[-0.4px]">
+                <div className="flex flex-col space-y-4 font-body-regular">
                     <Markdown
                         remarkPlugins={[remarkGfm]}
                         rehypePlugins={[rehypeRaw]}
                         components={{
-                            h3: ({ children }) => (
-                                <h3 className="first:mt-0 mt-4 mb-2 font-body-bold tracking-[-0.4px]">{children}</h3>
-                            ),
-                            p: ({ children }) => <p className="pl-1 font-body-regular tracking-[-0.4px]">{children}</p>,
-                            ul: ({ children }) => (
-                                <ul className="pl-1 font-body-regular tracking-[-0.4px]">{children}</ul>
-                            ),
-                            li: ({ children }) => (
-                                <li className="pl-1 font-body-regular tracking-[-0.4px]">{children}</li>
-                            ),
+                            h3: ({ children }) => <h3 className="first:mt-0 mt-4 mb-2 font-body-bold">{children}</h3>,
+                            p: ({ children }) => <p className="pl-1 font-body-regular">{children}</p>,
+                            ul: ({ children }) => <ul className="pl-1 font-body-regular">{children}</ul>,
+                            li: ({ children }) => <li className="pl-1 font-body-regular">{children}</li>,
                         }}
                     >
                         {ALGORITHM_CONTENT}

--- a/frontend/src/pages/report/_components/analysis/ViewerExitAnalysis.tsx
+++ b/frontend/src/pages/report/_components/analysis/ViewerExitAnalysis.tsx
@@ -12,7 +12,7 @@ export const ViewerExitAnalysis = () => {
             bg-surface-elevate-l1 p-6 overflow-y-auto overflow-hidden"
             >
                 <div className="flex flex-col space-y-4 font-body-regular">
-                    <p className="text-primary-600 font-body-regular">{EXIT_ANALYSIS_HIGHLIGHT}</p>
+                    <p className="text-primary-600 font-body-medium">{EXIT_ANALYSIS_HIGHLIGHT}</p>
                     <Markdown
                         remarkPlugins={[remarkGfm]}
                         rehypePlugins={[rehypeRaw]}

--- a/frontend/src/pages/report/_components/analysis/ViewerExitAnalysis.tsx
+++ b/frontend/src/pages/report/_components/analysis/ViewerExitAnalysis.tsx
@@ -11,22 +11,16 @@ export const ViewerExitAnalysis = () => {
                 className="w-full rounded-lg border border-gray-200
             bg-surface-elevate-l1 p-6 overflow-y-auto overflow-hidden"
             >
-                <div className="flex flex-col space-y-4 font-body-regular tracking-[-0.4px]">
-                    <p className="text-[#FF8389] font-body-regular tracking-[-0.4px]">{EXIT_ANALYSIS_HIGHLIGHT}</p>
+                <div className="flex flex-col space-y-4 font-body-regular">
+                    <p className="text-primary-600 font-body-regular">{EXIT_ANALYSIS_HIGHLIGHT}</p>
                     <Markdown
                         remarkPlugins={[remarkGfm]}
                         rehypePlugins={[rehypeRaw]}
                         components={{
-                            h3: ({ children }) => (
-                                <h3 className="mt-4 mb-2 font-body-bold tracking-[-0.4px]">{children}</h3>
-                            ),
-                            p: ({ children }) => <p className="pl-1 font-body-regular tracking-[-0.4px]">{children}</p>,
-                            ul: ({ children }) => (
-                                <ul className="pl-1 font-body-regular tracking-[-0.4px]">{children}</ul>
-                            ),
-                            li: ({ children }) => (
-                                <li className="pl-1 font-body-regular tracking-[-0.4px]">{children}</li>
-                            ),
+                            h3: ({ children }) => <h3 className="mt-4 mb-2 font-body-bold">{children}</h3>,
+                            p: ({ children }) => <p className="pl-1 font-body-regular">{children}</p>,
+                            ul: ({ children }) => <ul className="pl-1 font-body-regular">{children}</ul>,
+                            li: ({ children }) => <li className="pl-1 font-body-regular">{children}</li>,
                         }}
                     >
                         {EXIT_ANALYSIS}


### PR DESCRIPTION
## 💡 Related Issue

closed #79 

## ✅ Summary

전역 폰트 스타일 수정에 따라 코드 구조를 정리하고, 잘못된 폰트 스타일링을 수정했습니다.

## 📝 Description

- [x] 분석 탭의 텍스트 스타일을 Figma와 다시 비교하여 잘못 적용된 폰트 스타일 확인

- [x] 텍스트에 적절한 폰트 weight이 적용되었는지 검토
- EXIT_ANALYSIS_HIGHLIGHT에 잘못된 폰트 weight가 적용되어 `font-body-medium`으로 수정

- [x] 수정된 전역 폰트 스타일 기준에 맞춰 해당 스타일 수정

- [x] 코드 전체에서 동일한 폰트 스타일 적용 여부 점검 (필요 시 리팩토링)
- 수정된 전역 폰트 스타일에 tracking 값이 포함되어, 분석 탭 내 별도로 설정된 tracking 속성을 모두 제거했습니다.
