### PR TITLE
[DEV] 모달 공용 컴포넌트 사이즈 변환 방식 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,5 @@ dist-ssr
 *.sw?
 
 # env
-.env/*
+.env
+.env.local

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -1,31 +1,23 @@
-import { useEffect, useRef, type PropsWithChildren } from 'react'
-import clsx from 'clsx'
+import { useEffect, useLayoutEffect, useRef, useState, type PropsWithChildren } from 'react'
 import X from '../assets/icons/X.svg?react'
 
 interface ModalProps {
     title: string
     description?: string
     onClose: () => void
-    className?: string // className을 props로 전달하여 모달의 스타일 수정이 가능합니다. 예) className="w-[486px]" 전달하여 모달의 크기를 고정
 
     /**
-     * 모달의 수직 정렬 방식
-     * - 'center': 화면 세로 중앙 정렬 (기본값)
-     * - 'start': 상단 정렬 (스크롤이 필요한 textarea 등 내용이 긴 경우에 사용)
-     *   이 경우 className을 통해 mt-[값]으로 위치 조정
+     * 모달 컨테이너에 적용할 Tailwind 클래스
+     *
+     * - 모달의 크기나 여백 등의 스타일을 외부에서 조정할 수 있습니다.
+     * - 예: className="w-[486px]" → 모달 너비를 고정
      */
-    align?: 'center' | 'start'
+    className?: string
 }
 
-const Modal = ({
-    title,
-    description,
-    onClose,
-    className = '',
-    align = 'center',
-    children,
-}: PropsWithChildren<ModalProps>) => {
+const Modal = ({ title, description, onClose, className = '', children }: PropsWithChildren<ModalProps>) => {
     const modalRef = useRef<HTMLDivElement>(null)
+    const [marginTop, setMarginTop] = useState<number | null>(null)
 
     // ESC 키로 모달 창 닫기
     useEffect(() => {
@@ -36,6 +28,14 @@ const Modal = ({
         return () => window.removeEventListener('keydown', handleKeyDown)
     }, [onClose])
 
+    useLayoutEffect(() => {
+        if (!modalRef.current) return
+        const modalHeight = modalRef.current.getBoundingClientRect().height
+        const windowHeight = window.innerHeight
+        const calculatedMarginTop = Math.max((windowHeight - modalHeight) / 2, 24) // 최소 여백 확보
+        setMarginTop(calculatedMarginTop)
+    }, [])
+
     return (
         <div
             onClick={onClose} // 배경 클릭으로 모달 창 닫기
@@ -43,10 +43,7 @@ const Modal = ({
             role="dialog"
             aria-labelledby="modal-title"
             aria-describedby="modal-description"
-            className={clsx('fixed inset-0 z-50 flex justify-center min-w-[288px]', {
-                'items-center': align === 'center',
-                'items-start': align === 'start',
-            })}
+            className="fixed inset-0 z-50 flex items-start justify-center min-w-[288px]"
         >
             <div className="absolute inset-0 bg-neutral-black-opacity50" />
 
@@ -59,6 +56,7 @@ const Modal = ({
                     space-y-4 tablet:space-y-6 bg-surface-elevate-l2 p-6 rounded-3xl
                     ${className}
                 `}
+                style={marginTop !== null ? { marginTop } : undefined}
             >
                 <button
                     type="button"

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -29,11 +29,18 @@ const Modal = ({ title, description, onClose, className = '', children }: PropsW
     }, [onClose])
 
     useLayoutEffect(() => {
-        if (!modalRef.current) return
-        const modalHeight = modalRef.current.getBoundingClientRect().height
-        const windowHeight = window.innerHeight
-        const calculatedMarginTop = Math.max((windowHeight - modalHeight) / 2, 24) // 최소 여백 확보
-        setMarginTop(calculatedMarginTop)
+        const handleResize = () => {
+            if (modalRef.current) {
+                const modalHeight = modalRef.current.getBoundingClientRect().height
+                const windowHeight = window.innerHeight
+                const calculatedMarginTop = Math.max((windowHeight - modalHeight) / 2, 24)
+                setMarginTop(calculatedMarginTop)
+            }
+        }
+        handleResize()
+
+        window.addEventListener('resize', handleResize)
+        return () => window.removeEventListener('resize', handleResize)
     }, [])
 
     return (
@@ -77,12 +84,14 @@ const Modal = ({ title, description, onClose, className = '', children }: PropsW
                     >
                         {title}
                     </h1>
-                    <p
-                        id="modal-description"
-                        className="text-[14px] leading-[150%] tracking-[-0.35px] tablet:text-[16px] tablet:tracking-[-0.4px] text-gray-600"
-                    >
-                        {description}
-                    </p>
+                    {description && (
+                        <p
+                            id="modal-description"
+                            className="text-[14px] leading-[150%] tracking-[-0.35px] tablet:text-[16px] tablet:tracking-[-0.4px] text-gray-600"
+                        >
+                            {description}
+                        </p>
+                    )}
                 </div>
                 {children}
             </div>

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, type PropsWithChildren } from 'react'
+import clsx from 'clsx'
 import X from '../assets/icons/X.svg?react'
 
 interface ModalProps {
@@ -6,9 +7,24 @@ interface ModalProps {
     description?: string
     onClose: () => void
     className?: string // className을 props로 전달하여 모달의 스타일 수정이 가능합니다. 예) className="w-[486px]" 전달하여 모달의 크기를 고정
+
+    /**
+     * 모달의 수직 정렬 방식
+     * - 'center': 화면 세로 중앙 정렬 (기본값)
+     * - 'start': 상단 정렬 (스크롤이 필요한 textarea 등 내용이 긴 경우에 사용)
+     *   이 경우 className을 통해 mt-[값]으로 위치 조정
+     */
+    align?: 'center' | 'start'
 }
 
-const Modal = ({ title, description, onClose, className = '', children }: PropsWithChildren<ModalProps>) => {
+const Modal = ({
+    title,
+    description,
+    onClose,
+    className = '',
+    align = 'center',
+    children,
+}: PropsWithChildren<ModalProps>) => {
     const modalRef = useRef<HTMLDivElement>(null)
 
     // ESC 키로 모달 창 닫기
@@ -27,7 +43,10 @@ const Modal = ({ title, description, onClose, className = '', children }: PropsW
             role="dialog"
             aria-labelledby="modal-title"
             aria-describedby="modal-description"
-            className="fixed inset-0 z-50 flex items-center justify-center min-w-[288px]"
+            className={clsx('fixed inset-0 z-50 flex justify-center min-w-[288px]', {
+                'items-center': align === 'center',
+                'items-start': align === 'start',
+            })}
         >
             <div className="absolute inset-0 bg-neutral-black-opacity50" />
 

--- a/frontend/src/components/Textarea.tsx
+++ b/frontend/src/components/Textarea.tsx
@@ -29,13 +29,18 @@ const Textarea = ({
         const textarea = textareaRef.current
         if (!textarea) return
 
-        textarea.style.height = 'auto'
+        const handleResize = () => {
+            textarea.style.height = 'auto'
 
-        const isMobile = window.innerWidth <= 768
+            const isMobile = window.innerWidth <= 768
+            const maxLines = isMobile ? 3 : 5
+            const maxHeight = 32 * maxLines
+            textarea.style.height = Math.min(textarea.scrollHeight, maxHeight) + 'px'
+        }
+        handleResize()
 
-        const maxLines = isMobile ? 3 : 5
-        const maxHeight = 32 * maxLines
-        textarea.style.height = Math.min(textarea.scrollHeight, maxHeight) + 'px'
+        window.addEventListener('resize', handleResize)
+        return () => window.removeEventListener('resize', handleResize)
     }, [value])
 
     return (

--- a/frontend/src/hooks/useWindowWidth.ts
+++ b/frontend/src/hooks/useWindowWidth.ts
@@ -1,0 +1,21 @@
+import { useState, useEffect } from 'react'
+
+const useWindowWidth = () => {
+    const [windowWidth, setWindowWidth] = useState(window.innerWidth)
+
+    useEffect(() => {
+        const handleResize = () => {
+            setWindowWidth(window.innerWidth)
+        }
+
+        window.addEventListener('resize', handleResize)
+
+        return () => {
+            window.removeEventListener('resize', handleResize)
+        }
+    }, [])
+
+    return windowWidth
+}
+
+export default useWindowWidth

--- a/frontend/src/pages/auth/_components/ChannelConceptModal.tsx
+++ b/frontend/src/pages/auth/_components/ChannelConceptModal.tsx
@@ -12,7 +12,12 @@ export const ChannelConceptModal = ({ onClose, handleButtonClick, value, onChang
     const isActive = value.trim().length > 0
 
     return (
-        <Modal title={`마지막이에요! \n유튜버님의 채널 컨셉을 알려주세요.`} onClose={onClose}>
+        <Modal
+            title={`마지막이에요! \n유튜버님의 채널 컨셉을 알려주세요.`}
+            onClose={onClose}
+            className="mt-[30vh] tablet:mt-[37vh]"
+            align="start"
+        >
             <TextareaWithArrow
                 id="channelConcept"
                 value={value}

--- a/frontend/src/pages/auth/_components/ChannelConceptModal.tsx
+++ b/frontend/src/pages/auth/_components/ChannelConceptModal.tsx
@@ -1,5 +1,6 @@
 import Modal from '../../../components/Modal'
 import TextareaWithArrow from '../../../components/TextareaWithArrow'
+import useWindowWidth from '../../../hooks/useWindowWidth'
 
 interface ChannelConceptModalProps {
     onClose: () => void
@@ -10,6 +11,13 @@ interface ChannelConceptModalProps {
 
 export const ChannelConceptModal = ({ onClose, handleButtonClick, value, onChange }: ChannelConceptModalProps) => {
     const isActive = value.trim().length > 0
+    const windowWidth = useWindowWidth()
+
+    const getInitialRows = () => {
+        if (windowWidth < 768) return 3
+        else if (windowWidth < 1440) return 2
+        else return 1
+    }
 
     return (
         <Modal title={`마지막이에요! \n유튜버님의 채널 컨셉을 알려주세요.`} onClose={onClose}>
@@ -20,6 +28,7 @@ export const ChannelConceptModal = ({ onClose, handleButtonClick, value, onChang
                 handleButtonClick={handleButtonClick}
                 placeholder="정확한 분석을 위해 유튜버님의 채널 컨셉에 대한 설명을 입력해주세요. (예: 브이로그, 게임, 숏츠 위주)"
                 isActive={isActive}
+                initialRows={getInitialRows()}
             />
         </Modal>
     )

--- a/frontend/src/pages/auth/_components/ChannelConceptModal.tsx
+++ b/frontend/src/pages/auth/_components/ChannelConceptModal.tsx
@@ -12,12 +12,7 @@ export const ChannelConceptModal = ({ onClose, handleButtonClick, value, onChang
     const isActive = value.trim().length > 0
 
     return (
-        <Modal
-            title={`마지막이에요! \n유튜버님의 채널 컨셉을 알려주세요.`}
-            onClose={onClose}
-            className="mt-[30vh] tablet:mt-[37vh]"
-            align="start"
-        >
+        <Modal title={`마지막이에요! \n유튜버님의 채널 컨셉을 알려주세요.`} onClose={onClose}>
             <TextareaWithArrow
                 id="channelConcept"
                 value={value}

--- a/frontend/src/pages/auth/_components/ViewerModal.tsx
+++ b/frontend/src/pages/auth/_components/ViewerModal.tsx
@@ -1,5 +1,6 @@
 import Modal from '../../../components/Modal'
 import TextareaWithArrow from '../../../components/TextareaWithArrow'
+import useWindowWidth from '../../../hooks/useWindowWidth'
 
 interface ViewerModalProps {
     onClose: () => void
@@ -10,6 +11,13 @@ interface ViewerModalProps {
 
 export const ViewerModal = ({ onClose, value, onChange, handleButtonClick }: ViewerModalProps) => {
     const isActive = value.trim().length > 0
+    const windowWidth = useWindowWidth()
+
+    const getInitialRows = () => {
+        if (windowWidth < 768) return 3
+        else if (windowWidth < 1440) return 2
+        else return 1
+    }
 
     return (
         <Modal title={`30초면 완성해요! \n유튜버님의 시청자 타겟을 알려주세요.`} onClose={onClose}>
@@ -20,6 +28,7 @@ export const ViewerModal = ({ onClose, value, onChange, handleButtonClick }: Vie
                 handleButtonClick={handleButtonClick}
                 placeholder="정확한 분석을 위해 유튜버님의 시청자 타겟에 대한 설명을 입력해주세요. (예: 20대, 여성)"
                 isActive={isActive}
+                initialRows={getInitialRows()}
             />
         </Modal>
     )

--- a/frontend/src/pages/auth/_components/ViewerModal.tsx
+++ b/frontend/src/pages/auth/_components/ViewerModal.tsx
@@ -12,7 +12,12 @@ export const ViewerModal = ({ onClose, value, onChange, handleButtonClick }: Vie
     const isActive = value.trim().length > 0
 
     return (
-        <Modal title={`30초면 완성해요! \n유튜버님의 시청자 타겟을 알려주세요.`} onClose={onClose}>
+        <Modal
+            title={`30초면 완성해요! \n유튜버님의 시청자 타겟을 알려주세요.`}
+            onClose={onClose}
+            className="mt-[30vh] tablet:mt-[37vh]"
+            align="start"
+        >
             <TextareaWithArrow
                 id="viewer"
                 value={value}

--- a/frontend/src/pages/auth/_components/ViewerModal.tsx
+++ b/frontend/src/pages/auth/_components/ViewerModal.tsx
@@ -12,12 +12,7 @@ export const ViewerModal = ({ onClose, value, onChange, handleButtonClick }: Vie
     const isActive = value.trim().length > 0
 
     return (
-        <Modal
-            title={`30초면 완성해요! \n유튜버님의 시청자 타겟을 알려주세요.`}
-            onClose={onClose}
-            className="mt-[30vh] tablet:mt-[37vh]"
-            align="start"
-        >
+        <Modal title={`30초면 완성해요! \n유튜버님의 시청자 타겟을 알려주세요.`} onClose={onClose}>
             <TextareaWithArrow
                 id="viewer"
                 value={value}


### PR DESCRIPTION
## 💡 Related Issue

closed #90 
closed #83

## ✅ Summary

모달 공용 컴포넌트 사이즈 변환 방식을 수정합니다.

## 📝 Description

- [x] 모달이 사이즈가 늘어나는 경우 기존 위아래로 늘어나는 대신 아래로만 늘어날 수 있도록 align 설정을 추가했습니다.
- [x] 사이즈가 늘어날 필요가 없는 기존 모달에 변화가 생기는 것을 최대한 막기 위해 디폴트 값은 align='center'로 두고 늘어남이 필요한 곳에서만 align='start' className='mt-[]'을 설정할 수 있도록 구현했습니다.

```
interface ModalProps {
    title: string
    description?: string
    onClose: () => void
    className?: string 

    /**
     * 모달의 수직 정렬 방식
     * - 'center': 화면 세로 중앙 정렬 (기본값)
     * - 'start': 상단 정렬 (스크롤이 필요한 textarea 등 내용이 긴 경우에 사용)
     *   이 경우 className을 통해 mt-[값]으로 위치 조정
     */
    align?: 'center' | 'start'
}
```

## 💬 리뷰 요구 사항

일단 로그인 중 시청자 타겟, 채널 컨셉 모달에만 적용했는데, 혹시 작업하신 부분 중에 사이즈가 늘어나는 모달이 또 있는 경우 저한테 알려주시면 감사하겠습니다!
