### PR TITLE
[DEV] CI/CD 배포 자동화를 위한 GitHub Actions 워크플로우 및 빌드 스크립트 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: Channeling Frontend CI
+
+on:
+    push:
+        branches: ['main', 'develop']
+        paths:
+            - 'frontend/**'
+    pull_request:
+        branches: ['main', 'develop']
+        paths:
+            - 'frontend/**'
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+
+        defaults:
+            run:
+                working-directory: ./frontend
+
+        strategy:
+            matrix:
+                node-version: [20.x, 22.x]
+
+        steps:
+            - name: ▶️ Checkout repository
+              uses: actions/checkout@v4
+
+            - name: 📦 Setup pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  version: 10
+
+            - name: 🛠 Setup Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ matrix.node-version }}
+                  cache: 'pnpm'
+                  cache-dependency-path: frontend/pnpm-lock.yaml
+
+            - name: 📦 Install dependencies
+              run: pnpm install
+
+            - name: 🧹 Run lint
+              run: pnpm lint
+
+            - name: 🏗 Build project
+              run: pnpm build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: Deploy by Syncing
+
+on:
+    push:
+        branches: ['main', 'develop']
+
+jobs:
+    sync-and-deploy:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: ▶️ Checkout repository
+              uses: actions/checkout@v4
+
+            - name: 🛠 Create output directory for sync
+              run: sh ./scripts/build.sh
+
+            - name: 🕒 Set timestamp
+              run: echo "TIMESTAMP=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
+
+            - name: ✅ Push to another repository
+              uses: cpina/github-action-push-to-another-repository@main
+              env:
+                  API_TOKEN_GITHUB: ${{ secrets.GOM_AUTO_ACTIONS }}
+              with:
+                  source-directory: 'output'
+                  destination-github-username: 'gomx3'
+                  destination-repository-name: 'Channeling-FE-Production'
+                  user-email: ${{ secrets.GOM_EMAIL }}
+                  target-branch: ${{ github.ref_name }}
+                  commit-message: '[DEPLOY] Auto-sync from ${{ github.ref_name }} at ${{ env.TIMESTAMP }}'
+
+            - name: 🧪 Test get variable exported by push-to-another-repository
+              run: echo $DESTINATION_CLONED_DIRECTORY

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,9 @@
+{
+    "routes": [
+        {
+            "src": "/[^.]+",
+            "dest": "/index.html",
+            "status": 200
+        }
+    ]
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -e
+
+echo "[INFO] 소스 코드 파일 복사를 시작합니다."
+
+# 1. 루트 디렉토리에 이전 빌드 결과(output)가 남아있다면 삭제합니다.
+echo "[1/3] 기존 output 폴더를 정리합니다..."
+rm -rf output
+
+# 2. 빌드 결과물을 담을 output 폴더를 루트 디렉토리에 새로 생성합니다.
+echo "[2/3] 새로운 output 폴더를 생성합니다..."
+mkdir output
+
+# 3. 'output' 폴더를 제외한 모든 파일과 폴더를 복사합니다.
+echo "[3/3] 소스 파일들을 output 폴더로 복사합니다..."
+for item in *; do
+  if [ "$item" != "output" ]; then
+    cp -R "$item" "output/"
+  fi
+done
+
+echo "--- 파일 복사가 성공적으로 완료되었습니다 ---"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -19,4 +19,4 @@ for item in *; do
   fi
 done
 
-echo "--- 파일 복사가 성공적으로 완료되었습니다 ---"
+echo "[✅ SUCCESS] 파일 복사가 성공적으로 완료되었습니다"


### PR DESCRIPTION
## 💡 Related Issue

closed #92 

## ✅ Summary

CI 구축과 Vercel 배포 자동화를 위한 GitHub Actions 워크플로우(`ci.yml`, `deploy.yml`) 및 빌드 스크립트(`build.sh`)를 추가했습니다.

## 📝 Description

- [x] `ci.yml`
- `main`, `develop` 브랜치에 대한 push 및 pull_request 이벤트 발생 시 frontend/** 경로 내 변경사항에 대해 lint 및 build 테스트를 수행합니다.
- [x] `scripts/build.sh`
- 루트 디렉토리에서 output 폴더를 새로 생성하고, 기존 빌드 결과물을 정리한 후 필요한 파일들을 복사합니다.
- [x] `deploy.yml`
- `main`, `develop` 브랜치에 push 발생 시 자동 실행됩니다.
- 빌드된 소스를 output 디렉토리에 복사한 후, **gomx3/Channeling-FE-Production 레포지토리로 자동 푸시**합니다.
- [x] `vercel.json`
- Vercel에서 SPA 라우팅을 지원하기 위해 모든 경로를 `/index.html`로 리다이렉트하도록 설정했습니다. (fallback)
