### PR TITLE
[FIX] 내채널 페이지 lint 오류 수정

### DIFF
--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -18,9 +18,9 @@ const Pagination = ({ totalItems, itemCountPerPage, currentPage, onChangePage }:
     const noPrev = startPage == 1
 
     useEffect(() => {
-        if (currentPage >= startPage + 5 && !noNext) setStartPage(currentPage)
-        else if (currentPage <= startPage - 1 && !noPrev) setStartPage(currentPage - 4)
-    }, [currentPage])
+        if (currentPage >= startPage + 5 && !noNext) setStartPage(currentPage) // 다음 페이지 리스트
+        else if (currentPage <= startPage - 1 && !noPrev) setStartPage(currentPage - 4) // 이전 페이지 리스트
+    }, [noPrev, noNext, startPage, currentPage])
 
     return (
         <div className="flex items-center gap-[16px]">

--- a/frontend/src/pages/my/_components/myReportModal.tsx
+++ b/frontend/src/pages/my/_components/myReportModal.tsx
@@ -3,11 +3,10 @@ import Modal from '../../../components/Modal'
 
 interface MyReportModalProps {
     title: string
-    open: boolean
     setOpen: (open: boolean) => void
 }
 
-export const MyReportModal = ({ title, open, setOpen }: MyReportModalProps) => {
+export const MyReportModal = ({ title, setOpen }: MyReportModalProps) => {
     const navigate = useNavigate()
     const getReport = () => {
         setOpen(false)

--- a/frontend/src/pages/my/_components/myShortsCard.tsx
+++ b/frontend/src/pages/my/_components/myShortsCard.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import type { Shorts } from '../../../types/profile'
 import { formatKoreanNumber, formatRelativeTime } from '../../../utils/format'
-import { MyReportModal } from './myreportModal'
+import { MyReportModal } from './myReportModal'
 
 interface MyShortsCardProps {
     shorts: Shorts
@@ -28,7 +28,7 @@ export default function MyShortsCard({ shorts }: MyShortsCardProps) {
                     </div>
                 </div>
             </div>
-            {open && <MyReportModal title={shorts.title} open={open} setOpen={setOpen} />}
+            {open && <MyReportModal title={shorts.title} setOpen={setOpen} />}
         </>
     )
 }

--- a/frontend/src/pages/my/_components/myVideoCard.tsx
+++ b/frontend/src/pages/my/_components/myVideoCard.tsx
@@ -2,7 +2,7 @@ import type { Video } from '../../../types/profile'
 import { useState } from 'react'
 
 import { formatKoreanNumber, formatRelativeTime } from '../../../utils/format'
-import { MyReportModal } from './myreportModal'
+import { MyReportModal } from './myReportModal'
 
 interface MyVideoCardProps {
     video: Video
@@ -26,7 +26,7 @@ export default function MyVideoCard({ video }: MyVideoCardProps) {
                     </div>
                 </div>
             </div>
-            {open && <MyReportModal title={video.title} open={open} setOpen={setOpen} />}
+            {open && <MyReportModal title={video.title} setOpen={setOpen} />}
         </>
     )
 }


### PR DESCRIPTION
## 💡 Related Issue

closed #98 

## ✅ Summary

GitHub Actions CI에서 pnpm lint 단계에서 발생한 오류를 수정했습니다.


## 📝 Description

- [x] myReportModal에서 사용되지 않는 open 변수를 제거했습니다.
- [x] myShortsCard에서 임포트하고 있는 './myreportModal' 경로의 대소문자 오류를 수정했습니다.
- [x] myVideoCard에서 임포트하고 있는 './myreportModal' 경로의 대소문자 오류를 수정했습니다.
- [x] Pagination에서의 useEffect 의존성 배열에 'noPrev, noNext, startPage'를 추가했습니다. -> CI 경고 메세지 해결

## 💬 리뷰 요구 사항
