### PR TITLE
[FIX] 비로그인 시 '10초만에 로그인' 툴팁 안보이는 오류

### DIFF
--- a/frontend/src/components/common/Navbar/NavbarDesktop.tsx
+++ b/frontend/src/components/common/Navbar/NavbarDesktop.tsx
@@ -21,6 +21,11 @@ export const NavbarDesktop = () => {
 
     const handleUserClick = useOpenSetting()
 
+    const handleLoginClick = () => {
+        setTooltipPos(null)
+        openLoginFlow()
+    }
+
     useEffect(() => {
         const updateTooltipPosition = () => {
             if (!isAuth && loginButtonRef.current) {
@@ -53,7 +58,7 @@ export const NavbarDesktop = () => {
                 <NavbarLinksList
                     loginButtonRef={loginButtonRef}
                     handlePlusClick={handlePlusClick}
-                    handleLoginClick={openLoginFlow}
+                    handleLoginClick={handleLoginClick}
                     handleUserClick={handleUserClick}
                 />
             </div>


### PR DESCRIPTION
## 💡 Related Issue

closed #143 

## ✅ Summary

비로그인 상태에서 표시되어야 하는 로그인 안내 툴팁이 노출되지 않는 문제가 있습니다.
문제 원인을 파악하고 수정하여 툴팁이 정상적으로 표시되도록 해야 합니다.

## 📝 Description

- 툴팁이 사이드바에 가려 보이지 않는 점을 고려하여 z-index를 높게 설정했습니다.

- 로그인 버튼 클릭 시 툴팁이 사라지도록 기능을 추가했습니다.

## 💬 리뷰 요구 사항

