### PR TITLE
[DEV] 최초 로그인 과정에서 targets,concepts의 글자 제한 기능 추가

### DIFF
--- a/frontend/src/components/Textarea.tsx
+++ b/frontend/src/components/Textarea.tsx
@@ -8,6 +8,7 @@ interface TextareaProps {
     initialRows?: number // row 개수로 textarea 박스의 초기 높이를 지정할 수 있습니다. 디폴트는 1
     disabled?: boolean
     className?: string
+    maxLength?: number
 }
 
 const Textarea = ({
@@ -18,6 +19,7 @@ const Textarea = ({
     initialRows = 1,
     children,
     disabled = false,
+    maxLength,
     className,
 }: PropsWithChildren<TextareaProps>) => {
     const [isFocused, setIsFocused] = useState(false)
@@ -61,6 +63,7 @@ const Textarea = ({
                 onBlur={() => setIsFocused(false)}
                 rows={initialRows}
                 placeholder={placeholder}
+                maxLength={maxLength}
                 className="
                     w-full h-fit max-h-[120px] px-2 outline-none resize-none focus:placeholder-transparent
                     text-[14px] leading-[150%] tracking-[-0.35px] tablet:text-[16px] tablet:tracking-[-0.4px]

--- a/frontend/src/components/TextareaWithArrow.tsx
+++ b/frontend/src/components/TextareaWithArrow.tsx
@@ -12,6 +12,7 @@ interface TextareaWithArrowProps {
     isActive?: boolean // 화살표 버튼의 활성화 여부
     handleButtonClick?: () => void // 화살표 버튼을 클릭했을 때 실행할 함수를 전달합니다.
     buttonType?: ButtonType // button 태그의 타입을 지정합니다. 디폴트는 button
+    maxLength?: number // 설정 안 하면 무제한 (글자 제한)
 }
 
 const TextareaWithArrow = ({
@@ -22,10 +23,18 @@ const TextareaWithArrow = ({
     initialRows = 1,
     isActive = true,
     handleButtonClick,
+    maxLength,
     buttonType = 'button',
 }: TextareaWithArrowProps) => {
     return (
-        <Textarea id={id} value={value} onChange={onChange} placeholder={placeholder} initialRows={initialRows}>
+        <Textarea
+            id={id}
+            value={value}
+            onChange={onChange}
+            placeholder={placeholder}
+            initialRows={initialRows}
+            maxLength={maxLength}
+        >
             <div className="flex justify-end">
                 <ArrowButton type={buttonType} onClick={handleButtonClick} isActive={isActive} className="w-10 h-10" />
             </div>

--- a/frontend/src/hooks/channel/useFetchAndSetUser.ts
+++ b/frontend/src/hooks/channel/useFetchAndSetUser.ts
@@ -24,7 +24,7 @@ export function useFetchAndSetUser() {
         } catch (err) {
             console.error('❌ 회원 정보 조회 실패:', err)
             alert('회원 정보 조회 실패')
-            navigate('/')
+            navigate('/', { replace: true })
         }
     }
 

--- a/frontend/src/pages/auth/NavbarModalsContainer.tsx
+++ b/frontend/src/pages/auth/NavbarModalsContainer.tsx
@@ -15,7 +15,7 @@ export const NavbarModalsContainer = () => {
     const [viewerValue, setViewerValue] = useState('')
     const [channelConceptValue, setChannelConceptValue] = useState('')
 
-    const channelId = useAuthStore((state) => state.channelId)
+    const channelId = useAuthStore((state) => state.user?.channelId)
 
     const finishLoginAndAuthenticate = () => {
         setAuthMember()
@@ -74,7 +74,8 @@ export const NavbarModalsContainer = () => {
                                             setChannelConceptValue('') // 입력 초기화
                                             finishLoginAndAuthenticate()
                                         },
-                                        onError: () => {
+                                        onError: (err) => {
+                                            console.error('채널 콘셉트 실패:', err)
                                             alert('채널 콘셉트 저장 실패')
                                         },
                                     }

--- a/frontend/src/pages/auth/_components/ChannelConceptModal.tsx
+++ b/frontend/src/pages/auth/_components/ChannelConceptModal.tsx
@@ -28,6 +28,7 @@ export const ChannelConceptModal = ({ onClose, handleButtonClick, value, onChang
                 handleButtonClick={handleButtonClick}
                 placeholder="정확한 분석을 위해 유튜버님의 채널 컨셉에 대한 설명을 입력해주세요. (예: 브이로그, 게임, 숏츠 위주)"
                 isActive={isActive}
+                maxLength={500}
                 initialRows={getInitialRows()}
             />
         </Modal>

--- a/frontend/src/pages/auth/_components/ViewerModal.tsx
+++ b/frontend/src/pages/auth/_components/ViewerModal.tsx
@@ -28,6 +28,7 @@ export const ViewerModal = ({ onClose, value, onChange, handleButtonClick }: Vie
                 handleButtonClick={handleButtonClick}
                 placeholder="정확한 분석을 위해 유튜버님의 시청자 타겟에 대한 설명을 입력해주세요. (예: 20대, 여성)"
                 isActive={isActive}
+                maxLength={100}
                 initialRows={getInitialRows()}
             />
         </Modal>


### PR DESCRIPTION
## 💡 Related Issue

close #146 

## ✅ Summary

최초 로그인 과정에서 (회원가입에서) targets,concepts 정보를 받아올 때 글자 제한 기능을 추가합니다.
targets : 100자
concepts : 500자

## 📝 Description

Textarea, TextareaWithArrow Props 부분에 maxLength를 추가하였습니다.
로그인에 실패하였을 때 뒤로가기 기능을 제한두었습니다.
각각 모달에 maxLength 값을 넘기도록 하였습니다.

