### PR TITLE
[HOTFIX] 배포 환경 구글 로그인 오류 재수정으로 Proxy 설정 제거

### DIFF
--- a/frontend/src/api/axios.ts
+++ b/frontend/src/api/axios.ts
@@ -2,9 +2,9 @@ import axios from 'axios'
 import { LOCAL_STORAGE_KEY } from '../constants/key'
 
 export const axiosInstance = axios.create({
-    withCredentials: true,
-    baseURL: '/api',
-    // baseURL: import.meta.env.VITE_SERVER_API_URL,
+    // withCredentials: true,
+    // baseURL: '/api',
+    baseURL: import.meta.env.VITE_SERVER_API_URL,
 })
 
 // 요청 인터셉터


### PR DESCRIPTION
## 💡 Related Issue

#151

## ✅ Summary

배포 환경에서 구글 로그인 성공 후, 회원 정보 조회 API 호출에 실패하는 문제를 해결합니다.

## 📝 Description

- 배포 환경에서 auth-storage까지 저장되는 것을 확인했으므로 axios 설정을 다시 이전으로 돌립니다.
- axios.ts 및 관련 config 파일에 프록시(Proxy) 설정을 제거합니다.

