### PR TITLE
[FIX] 회원 정보 조회 응답에 동의 여부 추가

### DIFF
--- a/frontend/src/pages/setting/SettingPage.tsx
+++ b/frontend/src/pages/setting/SettingPage.tsx
@@ -60,6 +60,12 @@ export default function SettingPage({ onClose }: SettingPageProps) {
         })
     }, [user, formData.instagram, formData.tiktok, formData.facebook, formData.x, setFormData])
 
+    useEffect(() => {
+        if (!myProfile) return
+        setMarketingEmailAgree(myProfile.marketingEmailAgree)
+        setDayContentEmailAgree(myProfile.dayContentEmailAgree)
+    }, [myProfile, setMarketingEmailAgree, setDayContentEmailAgree])
+
     const handleCameraClick = () => fileInputRef.current?.click()
 
     const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/frontend/src/types/channel.ts
+++ b/frontend/src/types/channel.ts
@@ -19,6 +19,8 @@ export interface User {
     tiktokLink: string | null
     facebookLink: string | null
     twitterLink: string | null
+    marketingEmailAgree: boolean
+    dayContentEmailAgree: boolean
 }
 
 export type ResponseMyProfile = CommonResponse<User>


### PR DESCRIPTION
## 💡 Related Issue

closed #162 

## ✅ Summary

회원 정보 조회에 마케팅 및 일일 콘텐츠 이메일 동의 여부가 포함되지 않는 문제를 수정합니다.

## 📝 Description

- [x] User 타입에 marketingEmailAgree, dayContentEmailAgree 필드 추가
- [x] useFetchMyProfile 훅 응답을 기반으로 useContentStore 전역 상태를 초기화 처리
- 회원 정보 조회 API에 marketingEmailAgree, dayContentEmailAgree가 추가됨에 따라, User 타입에 해당 필드를 반영하여 해당 값을 기반으로 동의 상태를 초기화하도록 처리했습니다.
- 기존 전역 상태 방식은 새로고침 시 동의 상태에 문제가 있어, 최신 동의 상태를 반영하도록 수정했습니다.

