### PR TITLE
[DEV] 저장소 페이지 진입 시 리포트 목록 자동 갱신 기능 추가

### DIFF
--- a/frontend/src/pages/library/LibraryPage.tsx
+++ b/frontend/src/pages/library/LibraryPage.tsx
@@ -1,9 +1,23 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import ReportTab from './_components/ReportTab'
 import IdeaTab from './_components/IdeaTab'
+import { useQueryClient } from '@tanstack/react-query'
+import { useAuthStore } from '../../stores/authStore'
 
 export default function LibraryPage() {
     const [activeTab, setActiveTab] = useState<'report' | 'idea'>('report')
+    const queryClient = useQueryClient()
+    const user = useAuthStore((state) => state.user)
+    const channelId = user?.channelId
+
+    // 페이지 진입 시 리포트 목록 캐시 무효화
+    useEffect(() => {
+        if (typeof channelId === 'number') {
+            queryClient.invalidateQueries({
+                queryKey: ['my', 'report', channelId],
+            })
+        }
+    }, [channelId, queryClient])
 
     return (
         <div className="px-6 tablet:px-[76px] py-20">


### PR DESCRIPTION
## 💡 Related Issue

close #182 

## ✅ Summary

리포트 생성 후 저장소 페이지로 이동했을 때 새로고침 없이도 새로 생성된 리포트가 바로 목록에 표시되도록 개선했습니다.

## 📝 Description

- 리포트 생성 완료 후 저장소 페이지로 이동해도 새로 생성된 리포트가 목록에 바로 나타나지 않음
- 사용자가 수동으로 새로고침해야 최신 리포트를 확인할 수 있어 UX가 불편함
- LibraryPage에서 useEffect를 사용하여 페이지 진입 시 리포트 관련 쿼리 캐시를 무효화
- React Query의 invalidateQueries를 통해 자동으로 최신 데이터를 다시 조회하도록 구현
