### PR TITLE
[DEV] 링크 입력창 로그인 하고 돌아왔을 때 입력값 보존

### DIFF
--- a/frontend/src/hooks/main/useUrlInput.ts
+++ b/frontend/src/hooks/main/useUrlInput.ts
@@ -17,7 +17,7 @@ export const useUrlInput = (onRequestUrlSuccess?: (reportId: number, videoId: nu
 
     const savedUrl = (() => {
         try {
-            return localStorage.getItem(PENDING_KEY) ?? ''
+            return sessionStorage.getItem(PENDING_KEY) ?? ''
         } catch {
             return ''
         }
@@ -59,21 +59,9 @@ export const useUrlInput = (onRequestUrlSuccess?: (reportId: number, videoId: nu
         setIsActive(isValid && !error)
     }, [url, error])
 
-    useEffect(() => {
-        const handleUnload = () => {
-            try {
-                localStorage.removeItem(PENDING_KEY)
-            } catch {
-                // ignore
-            }
-        }
-        window.addEventListener('beforeunload', handleUnload)
-        return () => window.removeEventListener('beforeunload', handleUnload)
-    }, [])
-
     const clearPendingUrl = () => {
         try {
-            localStorage.removeItem(PENDING_KEY)
+            sessionStorage.removeItem(PENDING_KEY)
         } catch {
             // ignore
         }
@@ -85,7 +73,7 @@ export const useUrlInput = (onRequestUrlSuccess?: (reportId: number, videoId: nu
     const onSubmit: SubmitHandler<UrlForm> = async ({ url }) => {
         if (!isAuth) {
             try {
-                localStorage.setItem(PENDING_KEY, url)
+                sessionStorage.setItem(PENDING_KEY, url)
             } catch {
                 // ignore
             }

--- a/frontend/src/hooks/main/useUrlInput.ts
+++ b/frontend/src/hooks/main/useUrlInput.ts
@@ -39,7 +39,7 @@ export const useUrlInput = (onRequestUrlSuccess?: (reportId: number, videoId: nu
         },
     })
 
-    const { register, handleSubmit, watch } = useForm<UrlForm>({
+    const { register, handleSubmit, watch, reset } = useForm<UrlForm>({
         defaultValues: { url: savedUrl },
         resolver: zodResolver(urlSchema),
         mode: 'onChange',
@@ -59,6 +59,29 @@ export const useUrlInput = (onRequestUrlSuccess?: (reportId: number, videoId: nu
         setIsActive(isValid && !error)
     }, [url, error])
 
+    useEffect(() => {
+        const handleUnload = () => {
+            try {
+                localStorage.removeItem(PENDING_KEY)
+            } catch {
+                // ignore
+            }
+        }
+        window.addEventListener('beforeunload', handleUnload)
+        return () => window.removeEventListener('beforeunload', handleUnload)
+    }, [])
+
+    const clearPendingUrl = () => {
+        try {
+            localStorage.removeItem(PENDING_KEY)
+        } catch {
+            // ignore
+        }
+        reset({ url: '' })
+        setError(null)
+        setIsActive(false)
+    }
+
     const onSubmit: SubmitHandler<UrlForm> = async ({ url }) => {
         if (!isAuth) {
             try {
@@ -74,5 +97,5 @@ export const useUrlInput = (onRequestUrlSuccess?: (reportId: number, videoId: nu
         requestNewReport({ url }) // 리포트 생성 요청
     }
 
-    return { register, handleSubmit: handleSubmit(onSubmit), isActive, error }
+    return { register, handleSubmit: handleSubmit(onSubmit), isActive, error, clearPendingUrl }
 }

--- a/frontend/src/pages/main/_components/UrlInputForm.tsx
+++ b/frontend/src/pages/main/_components/UrlInputForm.tsx
@@ -22,6 +22,11 @@ export const UrlInputForm = () => {
 
     useEffect(() => {
         if (!isPending && videoData && reportId && videoId) {
+            try {
+                localStorage.removeItem('pending-url')
+            } catch {
+                // ignore
+            }
             navigate(`/report/${reportId}?video=${videoId}`)
         }
     }, [isPending, videoData, navigate, reportId, videoId])

--- a/frontend/src/pages/main/_components/UrlInputForm.tsx
+++ b/frontend/src/pages/main/_components/UrlInputForm.tsx
@@ -23,7 +23,7 @@ export const UrlInputForm = () => {
     useEffect(() => {
         if (!isPending && videoData && reportId && videoId) {
             try {
-                localStorage.removeItem('pending-url')
+                sessionStorage.removeItem('pending-url')
             } catch {
                 // ignore
             }

--- a/frontend/src/pages/main/_components/UrlInputModal.tsx
+++ b/frontend/src/pages/main/_components/UrlInputModal.tsx
@@ -27,6 +27,11 @@ export const UrlInputModal = ({ onClose }: UrlInputModalProps) => {
 
     useEffect(() => {
         if (!isPending && videoData && reportId && videoId) {
+            try {
+                localStorage.removeItem('pending-url')
+            } catch {
+                // ignore
+            }
             onClose()
             navigate(`/report/${reportId}?video=${videoId}`)
         }

--- a/frontend/src/pages/main/_components/UrlInputModal.tsx
+++ b/frontend/src/pages/main/_components/UrlInputModal.tsx
@@ -28,7 +28,7 @@ export const UrlInputModal = ({ onClose }: UrlInputModalProps) => {
     useEffect(() => {
         if (!isPending && videoData && reportId && videoId) {
             try {
-                localStorage.removeItem('pending-url')
+                sessionStorage.removeItem('pending-url')
             } catch {
                 // ignore
             }


### PR DESCRIPTION
## 💡 Related Issue

closed #178 

## ✅ Summary

화면설계서에 따르면, 비로그인 상태에서 링크 입력하고 우측 전송했을 경우 로그인을 하고 돌아왔을 때 입력값이 보존되어야 합니다. 아직 이 부분이 반영되어 있지 않기 때문에 해당 사항을 추가해야 합니다.

## 📝 Description

- [ ] 링크 입력창 URL 상태 관리

<img width="350" alt="Image" src="https://github.com/user-attachments/assets/ac100f00-ff23-4ecc-aba8-7a94b13d4ce1" />


- 기존에 url 입력값을 localStorage에 저장했으나, 새로고침 시에는 값을 유지하고 사이트 이탈 시에는 값이 삭제되도록 하기 위해 sessionStorage로 변경하였습니다.
- 리포트 생성에 성공하거나 사이트에 이탈할 경우 `sessionStorage.removeItem`으로 값을 삭제합니다.
- 입력값 복원 시에는 `sessionStorage.getItem`을 통해 초기화합니다.
