### PR TITLE
[FIX] SettingPage 동의 토글 누르면 불필요한 렌더링 발생 문제 해결

### DIFF
--- a/frontend/src/hooks/setting/useFetchMyProfile.ts
+++ b/frontend/src/hooks/setting/useFetchMyProfile.ts
@@ -2,8 +2,8 @@ import { useQuery } from '@tanstack/react-query'
 import type { User } from '../../types/channel'
 import { fetchMyProfile as fetchMyProfileAPI } from '../../api/user'
 
-export const useFetchMyProfile = (enabled = true) => {
-    return useQuery<User, Error, User, [string]>({
+export function useFetchMyProfile<T = User>(options?: { enabled?: boolean; select?: (data: User | undefined) => T }) {
+    return useQuery<User, Error, T, ['my-profile']>({
         queryKey: ['my-profile'],
         // import한 API 함수 사용
         queryFn: async () => {
@@ -12,6 +12,7 @@ export const useFetchMyProfile = (enabled = true) => {
         },
         staleTime: Infinity,
         retry: false,
-        enabled,
+        enabled: options?.enabled ?? true,
+        select: options?.select,
     })
 }

--- a/frontend/src/pages/setting/_containers/ConsentSettings.tsx
+++ b/frontend/src/pages/setting/_containers/ConsentSettings.tsx
@@ -1,37 +1,69 @@
+import { useQueryClient } from '@tanstack/react-query'
 import { useUpdateMemberAgree } from '../../../hooks/setting/userMutations'
-import { useAuthStore } from '../../../stores/authStore'
 import ConsentTab from '../_components/ConsentTab'
+import { useFetchMyProfile } from '../../../hooks/setting/useFetchMyProfile'
+import { useCallback } from 'react'
+import type { User } from '../../../types/channel'
 
 export default function ConsentSettings() {
-    const { user } = useAuthStore()
-    const { setUser } = useAuthStore((state) => state.actions)
+    const qc = useQueryClient()
+
+    const { data: consent } = useFetchMyProfile({
+        select: (u) => ({
+            marketingEmailAgree: u?.marketingEmailAgree ?? false,
+            dayContentEmailAgree: u?.dayContentEmailAgree ?? false,
+        }),
+    })
+
     const { mutate: updateAgree } = useUpdateMemberAgree()
 
-    const handleAgreeChange = (key: 'marketingEmailAgree' | 'dayContentEmailAgree', value: boolean) => {
-        const payload = {
-            marketingEmailAgree: key === 'marketingEmailAgree' ? value : user?.marketingEmailAgree ?? false,
-            dayContentEmailAgree: key === 'dayContentEmailAgree' ? value : user?.dayContentEmailAgree ?? false,
-        }
+    const handleChange = useCallback(
+        (key: 'marketingEmailAgree' | 'dayContentEmailAgree', value: boolean) => {
+            const prev = qc.getQueryData<User>(['my-profile'])
 
-        updateAgree(payload, {
-            onSuccess: (data) => {
-                if (!user) return
-                setUser({
-                    ...user,
-                    marketingEmailAgree: data.result.marketingEmailAgree,
-                    dayContentEmailAgree: data.result.dayContentEmailAgree,
-                })
-            },
-            onError: () => alert('존재하지 않는 회원 동의입니다.'),
-        })
-    }
+            qc.setQueryData<User>(['my-profile'], (old) => {
+                if (!old) return old
+                return {
+                    ...old,
+                    marketingEmailAgree: key === 'marketingEmailAgree' ? value : old.marketingEmailAgree ?? false,
+                    dayContentEmailAgree: key === 'dayContentEmailAgree' ? value : old.dayContentEmailAgree ?? false,
+                }
+            })
+
+            updateAgree(
+                {
+                    marketingEmailAgree: key === 'marketingEmailAgree' ? value : consent?.marketingEmailAgree ?? false,
+                    dayContentEmailAgree:
+                        key === 'dayContentEmailAgree' ? value : consent?.dayContentEmailAgree ?? false,
+                },
+                {
+                    onError: () => {
+                        qc.setQueryData(['my-profile'], prev)
+                        alert('존재하지 않는 회원 동의입니다.')
+                    },
+                    onSuccess: (data) => {
+                        qc.setQueryData<User>(['my-profile'], (old) =>
+                            old
+                                ? {
+                                      ...old,
+                                      marketingEmailAgree: data.result.marketingEmailAgree,
+                                      dayContentEmailAgree: data.result.dayContentEmailAgree,
+                                  }
+                                : old
+                        )
+                    },
+                }
+            )
+        },
+        [consent, qc, updateAgree]
+    )
 
     return (
         <ConsentTab
-            marketingEmail={user?.marketingEmailAgree ?? false}
-            dailyContentEmail={user?.dayContentEmailAgree ?? false}
-            onMarketingChange={(value) => handleAgreeChange('marketingEmailAgree', value)}
-            onDailyContentChange={(value) => handleAgreeChange('dayContentEmailAgree', value)}
+            marketingEmail={consent?.marketingEmailAgree ?? false}
+            dailyContentEmail={consent?.dayContentEmailAgree ?? false}
+            onMarketingChange={(value) => handleChange('marketingEmailAgree', value)}
+            onDailyContentChange={(value) => handleChange('dayContentEmailAgree', value)}
         />
     )
 }

--- a/frontend/src/pages/setting/_containers/ProfileSettings.tsx
+++ b/frontend/src/pages/setting/_containers/ProfileSettings.tsx
@@ -16,7 +16,7 @@ export default function ProfileSettings({ onOpenWithdraw, fetchEnabled }: Props)
     const fileInputRef = useRef<HTMLInputElement>(null)
 
     const { user } = useAuthStore()
-    const { data: myProfile } = useFetchMyProfile(fetchEnabled)
+    const { data: myProfile } = useFetchMyProfile({ enabled: fetchEnabled })
 
     const { setFormData, resetFormData, ownerId, setOwner, formData } = useSNSFormStore()
     const { mutate: updateProfileImage } = useUpdateMemberProfileImage()


### PR DESCRIPTION
## 💡 Related Issue

 closed #193 

## ✅ Summary

동의 탭에서 토글을 누를 시 전체 페이지가 리렌더링되는 문제가 발생합니다.

## 📝 Description

- [x] 전역 상태 갱신 방식을 수정 (user 업데이트 X, 리렌더링 범위 축소)
- [x] 중복 API 호출 차단
- 전역 user 대신 useFetchMyProfile 단일 소스로 동의 상태를 관리했습니다.
- select 옵션을 활용해 동의 관련 필드만 추출해 불필요한 리렌더링을 줄였습니다.