### PR TITLE
[DEV] 로그아웃 시 auth-storage 및 sns-form-storage 초기화

### DIFF
--- a/frontend/src/hooks/useLogout.ts
+++ b/frontend/src/hooks/useLogout.ts
@@ -5,12 +5,13 @@ import { useQueryClient } from '@tanstack/react-query'
 export function useLogout() {
     const navigate = useNavigate()
     const queryClient = useQueryClient()
-    try {
-        queryClient.clear()
-    } catch (e) {
-        console.warn('Query cache clear 실패:', e)
-    }
+
     return async () => {
+        try {
+            queryClient.clear()
+        } catch (e) {
+            console.warn('Query cache clear 실패:', e)
+        }
         await logoutCore()
         navigate('/', { replace: true })
     }

--- a/frontend/src/layouts/_components/navbar/NavbarTablet.tsx
+++ b/frontend/src/layouts/_components/navbar/NavbarTablet.tsx
@@ -48,7 +48,7 @@ export const NavbarTablet = () => {
             >
                 <div className="flex flex-row items-center justify-between">
                     <Link to="/">
-                        <Channeling aria-label="Channeling 글자 로고" />
+                        <Channeling className="text-primary-500" aria-label="Channeling 글자 로고" />
                     </Link>
                     <button aria-label="사이드 바 닫기" onClick={toggleMenu} className="cursor-pointer">
                         <X />

--- a/frontend/src/pages/setting/SettingPage.tsx
+++ b/frontend/src/pages/setting/SettingPage.tsx
@@ -5,7 +5,6 @@ import CloseIcon from '../../assets/icons/delete_normal.svg?react'
 import LogoutIcon from '../../assets/icons/logout.svg?react'
 import WithdrawlModal from './_components/WithdrawlModal'
 import { useLogout } from '../../hooks/useLogout'
-import { useSNSFormStore } from '../../stores/snsFormStore'
 import ProfileSettings from './_containers/ProfileSettings'
 import ConsentSettings from './_containers/ConsentSettings'
 
@@ -20,15 +19,9 @@ export default function SettingPage({ onClose }: SettingPageProps) {
     const logout = useLogout()
     const [loggingOut, setLoggingOut] = useState(false)
 
-    const { resetFormData, setOwner } = useSNSFormStore()
-
     const handleClickLogout = async () => {
         if (loggingOut) return
         setLoggingOut(true)
-
-        useSNSFormStore.persist?.clearStorage?.()
-        resetFormData()
-        setOwner(null)
 
         await logout()
         onClose?.()

--- a/frontend/src/utils/auth.ts
+++ b/frontend/src/utils/auth.ts
@@ -1,6 +1,7 @@
 import { axiosInstance } from '../api/axios'
 import { LOCAL_STORAGE_KEY } from '../constants/key'
 import { useAuthStore } from '../stores/authStore'
+import { useSNSFormStore } from '../stores/snsFormStore'
 
 export async function logoutCore() {
     // 1) 토큰 삭제
@@ -14,8 +15,19 @@ export async function logoutCore() {
     try {
         const { clearAuth } = useAuthStore.getState().actions
         clearAuth?.()
+
+        const { resetFormData, setOwner } = useSNSFormStore.getState()
+        resetFormData()
+        setOwner(null)
     } catch (e) {
         console.error('auth 상태 초기화 실패:', e)
+    }
+
+    try {
+        useAuthStore.persist?.clearStorage?.()
+        useSNSFormStore.persist?.clearStorage?.()
+    } catch (e) {
+        console.error('persist clear 실패: ', e)
     }
 
     // 3) axios Authorization 기본값 제거(방어적)


### PR DESCRIPTION
## 💡 Related Issue

closed #197 

## ✅ Summary

현재 로그아웃 시 accessToken만 제거되고 있어, auth-storage와 sns-form-storage도 초기화되도록 수정합니다.

## 📝 Description

- [x] 로그아웃 시 auth-storage 초기화 로직 추가
- [x] 로그아웃 시 sns-form-storage 초기화 로직 추가

- 로그아웃 시 남던 auth-storage와 sns-form-storage를 초기화했습니다.
- useLogout의 queryClient.clear()를 훅 초기화 시점이 아닌 콜백 내부로 이동시켰습니다.
- SettingPage의 중복 초기화 코드를 제거했습니다.
