### PR TITLE
[DEV] Gemini 자동 리뷰 워크플로우 트리거 조건 수정

### DIFF
--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -2,7 +2,7 @@ name: PR Auto Review with Gemini
 
 on:
     pull_request:
-        types: [labeled]
+        types: [opened, labeled]
         branches:
             - develop
         paths:

--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -2,7 +2,7 @@ name: PR Auto Review with Gemini
 
 on:
     pull_request:
-        types: [opened, synchronize, reopened]
+        types: [labeled]
         branches:
             - develop
         paths:
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
     gemini-review:
+        if: github.event.label.name == 'gemini-pr-review'
         runs-on: ubuntu-latest
 
         steps:


### PR DESCRIPTION
## 💡 Related Issue

closed #142 

## ✅ Summary

Gemini AI 코드 리뷰 GitHub Actions 워크플로우의 트리거 조건을 변경하여, 개발자가 명시적으로 요청할 때만 실행되도록 개선했습니다. 이를 통해 불필요한 코멘트의 반복 생성과 리소스의 낭비 문제를 해결할 수 있습니다.

## 📝 Description

- [x] **트리거 조건 변경:**
`pull_request`의 `synchronize` 이벤트 대신, `labeled` 이벤트에만 반응하도록 수정했습니다.
- [x] **실행 조건 추가:**
`gemini-pr-review` 라벨이 추가되었을 때만 잡(job)이 실행되도록 `if: github.event.label.name == 'gemini-pr-review'` 조건을 추가했습니다.

### 새로운 리뷰 요청 방법

앞으로 Gemini AI에게 코드 리뷰를 요청하는 방식은 다음과 같습니다.

1. PR을 생성하고 자유롭게 커밋을 푸시하며 개발을 진행합니다.
2. Gemini의 리뷰가 필요하다고 생각되는 시점에, 해당 PR의 Labels 섹션에서 `gemini-pr-review` 라벨을 추가합니다.
3. 라벨이 추가되는 순간, Gemini 리뷰 워크플로우가 한 번 실행되어 리뷰 코멘트를 남깁니다.
4. 피드백을 반영한 후 재리뷰를 받고 싶다면, 기존 라벨을 삭제했다가 다시 추가하면 됩니다.

