### PR TITLE
[FIX] 아이디어 툴팁 디폴트 수정

### DIFF
--- a/frontend/src/pages/idea/_components/GeneratingIdea.tsx
+++ b/frontend/src/pages/idea/_components/GeneratingIdea.tsx
@@ -9,7 +9,7 @@ import usePostIdea from '../../../hooks/idea/usePostIdea'
 import type { PostIdeaDto } from '../../../types/idea'
 
 export const GeneratingIdea = () => {
-    const [isTooltipOpen, setIsTooltipOpen] = useState(true)
+    const [isTooltipOpen, setIsTooltipOpen] = useState(() => localStorage.getItem('ideaTooltipSeen') !== 'true')
     const [isDropdownOpen, setIsDropdownOpen] = useState(false)
     const [keyword, setKeyword] = useState('')
     const [additionalInfo, setAdditionalInfo] = useState('')
@@ -20,7 +20,18 @@ export const GeneratingIdea = () => {
     }
 
     const handleClick = () => {
-        setIsTooltipOpen((prev) => !prev)
+        setIsTooltipOpen((prev) => {
+            const isOpening = !prev
+            if (!isOpening) {
+                // 툴팁을 닫을 때
+                try {
+                    localStorage.setItem('ideaTooltipSeen', 'true')
+                } catch (e) {
+                    console.error('Failed to write ideaTooltipiSeen to localStorage:', e)
+                }
+            }
+            return isOpening
+        })
     }
 
     const handleOptionClick = (e: React.MouseEvent<HTMLDivElement>, option: string) => {


### PR DESCRIPTION
## 💡 Related Issue

- closed #230 

## ✅ Summary

아이디어 페이지의 툴팁의 디폴트 값을 수정했습니다.
툴팁 읽음을 로컬스토리지에 저장해서, 툴팁을 한 번 읽은 경우, 닫혀있도록 했습니다.

## 📝 Description

useState(false)->useState(true)
툴팁이 열려있는 것이 기본값이 되게 수정했습니다.

