### PR TITLE
[DEV] 마크다운 박스 폰트 크기 수정

### DIFF
--- a/frontend/src/components/MarkdownBox.tsx
+++ b/frontend/src/components/MarkdownBox.tsx
@@ -10,11 +10,11 @@ export const MarkdownBox = ({ content }: MarkdownBoxProps) => {
     return (
         <div
             className="prose prose-invert max-w-none
-                prose-headings:mt-4
-                prose-h1:text-[20px] prose-h1:leading-[150%] prose-h1:tracking-[-0.4px] prose-h1:font-bold prose-h1:text-gray-900
-                prose-h2:text-[18px] prose-h2:leading-[150%] prose-h2:tracking-[-0.4px] prose-h2:font-bold prose-h2:text-gray-900
-                prose-h3:text-[16px] prose-h3:leading-[150%] prose-h3:tracking-[-0.4px] prose-h3:font-bold prose-h3:text-gray-900
-                prose-h4:text-[16px] prose-h4:leading-[150%] prose-h4:tracking-[-0.4px] prose-h4:font-bold prose-h4:text-gray-900
+                prose-headings:mt-0 prose-headings:leading-[150%] prose-headings:tracking-[-0.4px] prose-headings:font-bold prose-headings:text-gray-900
+                prose-h1:text-[20px]
+                prose-h2:text-[18px]
+                prose-h3:text-[16px]
+                prose-h4:text-[16px]
                 prose-p:font-body-16r prose-p:text-gray-900
                 prose-a:text-primary-600 prose-a:hover:underline
 

--- a/frontend/src/styles/typo.css
+++ b/frontend/src/styles/typo.css
@@ -1,4 +1,4 @@
-@layer utilities {
+@layer components {
     .font-title-100r {
         @apply text-[80px] leading-[140%] tracking-[-2.5px] font-normal;
         @apply tablet:text-[100px]; /* Mobile -> Desktop */


### PR DESCRIPTION
## 💡 Related Issue

resolved #232 

## ✅ Summary

마크다운 박스의 h1, h2, h3 태그에 대한 글자 크기를 기획/디자인 측의 의견에 따라 변경했습니다.

## 📝 Description

- `h1`: 20px
- `h2`: 18px
- `h3` 이하: 16px

<img width="450"  alt="image" src="https://github.com/user-attachments/assets/1bbd7462-0a4e-4e19-b31b-c7fce5904a49" />

