### PR TITLE
[DEV] 업데이트 요약 섹션 표시 조건 로직 수정

### DIFF
--- a/frontend/src/pages/report/_components/overview/Skeleton.tsx
+++ b/frontend/src/pages/report/_components/overview/Skeleton.tsx
@@ -1,11 +1,17 @@
 import { BaseSkeleton, TitledSkeleton } from '../../../../components/Skeleton'
 
-export const Skeleton = () => {
+interface SkeletonProps {
+    showUpdateSummary: boolean
+}
+
+export const Skeleton = ({ showUpdateSummary }: SkeletonProps) => {
     return (
         <div className="space-y-16">
-            <TitledSkeleton>
-                <BaseSkeleton sizeConfig="w-full min-h-30" />
-            </TitledSkeleton>
+            {showUpdateSummary && (
+                <TitledSkeleton>
+                    <BaseSkeleton sizeConfig="w-full min-h-30" />
+                </TitledSkeleton>
+            )}
             <div className="grid grid-cols-1 desktop:grid-cols-2 gap-16 desktop:gap-6">
                 <TitledSkeleton>
                     <div className="grid grid-cols-3 gap-3">

--- a/frontend/src/pages/report/_components/overview/TabOverview.tsx
+++ b/frontend/src/pages/report/_components/overview/TabOverview.tsx
@@ -31,12 +31,13 @@ export const TabOverview = ({ reportId, isDummy = false }: TabOverviewProps) => 
 
     const overviewData = isDummy ? dummyData : realData
     const isLoading = isDummy ? isDummyLoading : !isCompleted || isRealLoading
+    const shouldShowUpdateSummary = !isDummy && !!overviewData?.updateSummary?.trim()
 
-    if (isLoading || !overviewData) return <Skeleton />
+    if (isLoading || !overviewData) return <Skeleton showUpdateSummary={shouldShowUpdateSummary} />
 
     return (
         <div className="space-y-16">
-            {!isDummy && overviewData.updateSummary?.trim() && <UpdateSummary data={overviewData} />}
+            {shouldShowUpdateSummary && <UpdateSummary data={overviewData} />}
             <EvaluationAndSummary data={overviewData} />
             <CommentFeedback data={overviewData} isDummy={isDummy} />
         </div>

--- a/frontend/src/pages/report/_components/overview/UpdateSummary.tsx
+++ b/frontend/src/pages/report/_components/overview/UpdateSummary.tsx
@@ -2,6 +2,8 @@ import { TitledSection } from '../../../../components/TitledSection'
 import type { OverviewDataProps } from '../../../../types/report/all'
 
 export const UpdateSummary = ({ data }: OverviewDataProps) => {
+    if (!data.updateSummary?.trim()) return null
+
     return (
         <TitledSection title="업데이트 요약">
             <div className="p-6 border border-gray-200 rounded-lg bg-surface-elevate-l1 overflow-y-auto">


### PR DESCRIPTION
## 💡 Related Issue

closed #249 

## ✅ Summary

업데이트 이력에 따른 업데이트 요약 섹션 노출 조건을 설정합니다.

## 📝 Description

- [x] 데모 리포트: 업데이트 요약 섹션 미노출
- [x] 실제 리포트: 업데이트 이력이 있는 경우에만 노출
- [x] 스켈레톤에 업데이트 요약 노출 조건 설정
