### PR TITLE
[DEV] 데모 리포트 페이지에서 생성 상태 조회하는 오류 해결

### DIFF
--- a/frontend/src/hooks/report/useReportStatus.ts
+++ b/frontend/src/hooks/report/useReportStatus.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import { getReportStatus } from '../../api/report'
 import { useMemo } from 'react'
 
-export const useReportStatus = (reportId: number) => {
+export const useReportStatus = (reportId: number, isDummy: boolean = false) => {
     const {
         data: statusData,
         isLoading,
@@ -12,10 +12,11 @@ export const useReportStatus = (reportId: number) => {
         queryFn: () => getReportStatus({ reportId }),
         staleTime: 0,
         retry: false,
-        enabled: !!reportId,
+        enabled: !!reportId && !isDummy,
         refetchInterval: (query) => {
-            const data = query.state.data
+            if (isDummy) return false
 
+            const data = query.state.data
             if (!data) return false
 
             const result = data?.result
@@ -40,6 +41,7 @@ export const useReportStatus = (reportId: number) => {
     })
 
     const serverStatus = useMemo(() => {
+        if (isDummy) return 'COMPLETED'
         if (isLoading) return 'LOADING'
         if (isError) return 'FAILED'
 
@@ -52,7 +54,7 @@ export const useReportStatus = (reportId: number) => {
         if (overviewStatus === 'COMPLETED' && analysisStatus === 'COMPLETED') return 'COMPLETED'
 
         return 'PROCESSING'
-    }, [statusData, isLoading, isError])
+    }, [isDummy, statusData, isLoading, isError])
 
     return {
         status: serverStatus, // 'LOADING' | 'PROCESSING' | 'COMPLETED' | 'FAILED'

--- a/frontend/src/pages/report/_components/analysis/TabAnalysis.tsx
+++ b/frontend/src/pages/report/_components/analysis/TabAnalysis.tsx
@@ -13,7 +13,7 @@ interface TabAnalysisProps {
 }
 
 export const TabAnalysis = ({ reportId, isDummy = false }: TabAnalysisProps) => {
-    const { rawResult, isLoading: isStatusLoading } = useReportStatus(reportId)
+    const { rawResult, isLoading: isStatusLoading } = useReportStatus(reportId, isDummy)
     const isCompleted = rawResult?.analysisStatus === 'COMPLETED'
 
     const { data: realData, isLoading: isRealLoading } = useGetReportAnalysis({

--- a/frontend/src/pages/report/_components/overview/TabOverview.tsx
+++ b/frontend/src/pages/report/_components/overview/TabOverview.tsx
@@ -15,7 +15,7 @@ interface TabOverviewProps {
 }
 
 export const TabOverview = ({ reportId, isDummy = false }: TabOverviewProps) => {
-    const { rawResult, isLoading: isStatusLoading } = useReportStatus(reportId)
+    const { rawResult, isLoading: isStatusLoading } = useReportStatus(reportId, isDummy)
     const isCompleted = rawResult?.overviewStatus === 'COMPLETED'
 
     const { data: realData, isLoading: isRealLoading } = useGetReportOverview({


### PR DESCRIPTION
## ✅ Summary

데모 리포트 페이지에서 생성 상태 조회하는 오류를 해결했습니다.

## 📝 Description

- 리포트 Tab 컴포넌트의 상태 조회 훅의 누락되었던 isDummy 전달을 추가 
